### PR TITLE
[Fix] 무한 스크롤 기능 도입 이후 발생한 문제 해결

### DIFF
--- a/lib/Provider/FoldersProvider.dart
+++ b/lib/Provider/FoldersProvider.dart
@@ -99,6 +99,15 @@ class FoldersProvider with ChangeNotifier {
     return _folderCache[folderId]?.problemHasNext ?? false;
   }
 
+  // 캐시 존재 여부 확인 (빈 리스트도 유효한 캐시)
+  bool hasSubfolderCache(int folderId) {
+    return _folderCache.containsKey(folderId);
+  }
+
+  bool hasProblemCache(int folderId) {
+    return _folderCache.containsKey(folderId);
+  }
+
   // 외부에서 캐시에 데이터 저장 (DirectoryScreen에서 사용)
   void saveSubfoldersToCache(
     int folderId,

--- a/lib/Provider/FoldersProvider.dart
+++ b/lib/Provider/FoldersProvider.dart
@@ -370,14 +370,11 @@ class FoldersProvider with ChangeNotifier {
     // 루트 폴더이면 타임스탬프 업데이트
     if (rootFolder != null && folderId == rootFolder!.folderId) {
       _rootFolderRefreshTimestamp = DateTime.now().millisecondsSinceEpoch;
-      log('Root folder refresh signaled - timestamp: $_rootFolderRefreshTimestamp');
+      log('🔄 Root folder refresh signaled - timestamp: $_rootFolderRefreshTimestamp');
     }
 
-    // 현재 폴더이면 다시 로드
-    if (_currentFolder?.folderId == folderId) {
-      await moveToFolder(folderId);
-    }
-
+    // DirectoryScreen이 독립적으로 데이터를 로드하므로, moveToFolder를 호출하지 않음
+    // 대신 notifyListeners()로 UI에 알림
     notifyListeners();
   }
 

--- a/lib/Provider/FoldersProvider.dart
+++ b/lib/Provider/FoldersProvider.dart
@@ -82,6 +82,63 @@ class FoldersProvider with ChangeNotifier {
     return _folderCache[_currentFolder!.folderId]?.problemHasNext ?? false;
   }
 
+  // 특정 폴더의 데이터 직접 접근 (화면 독립성을 위한 메서드)
+  List<FolderThumbnailModel> getSubfoldersForFolder(int folderId) {
+    return _folderCache[folderId]?.subfolders ?? [];
+  }
+
+  List<ProblemModel> getProblemsForFolder(int folderId) {
+    return _folderCache[folderId]?.problems ?? [];
+  }
+
+  bool getSubfolderHasNextForFolder(int folderId) {
+    return _folderCache[folderId]?.subfolderHasNext ?? false;
+  }
+
+  bool getProblemHasNextForFolder(int folderId) {
+    return _folderCache[folderId]?.problemHasNext ?? false;
+  }
+
+  // 외부에서 캐시에 데이터 저장 (DirectoryScreen에서 사용)
+  void saveSubfoldersToCache(
+    int folderId,
+    List<FolderThumbnailModel> subfolders,
+    int? nextCursor,
+    bool hasNext,
+  ) {
+    // 캐시가 없으면 생성
+    if (!_folderCache.containsKey(folderId)) {
+      _folderCache[folderId] = FolderScrollState();
+    }
+
+    final state = _folderCache[folderId]!;
+    state.subfolders = List.from(subfolders); // 복사본 저장
+    state.subfolderNextCursor = nextCursor;
+    state.subfolderHasNext = hasNext;
+
+    log('💾 Saved ${subfolders.length} subfolders to cache for folder $folderId');
+  }
+
+  // 외부에서 문제 데이터를 캐시에 저장
+  void saveProblemsToCache(
+    int folderId,
+    List<ProblemModel> problems,
+    int? nextCursor,
+    bool hasNext,
+  ) {
+    // 캐시가 없으면 생성
+    if (!_folderCache.containsKey(folderId)) {
+      _folderCache[folderId] = FolderScrollState();
+    }
+
+    final state = _folderCache[folderId]!;
+    state.problems = List.from(problems); // 복사본 저장
+    state.problemNextCursor = nextCursor;
+    state.problemHasNext = hasNext;
+
+    log('💾 Saved ${problems.length} problems to cache for folder $folderId');
+  }
+
   FoldersProvider({required this.problemsProvider});
 
   // O(log n) 삽입/업데이트 (SplayTreeMap이 자동으로 정렬 유지)

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -163,15 +163,6 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
       });
     }
 
-    // 캐시 존재 여부 확인
-    final hasCache = foldersProvider.hasSubfolderCache(targetFolderId) ||
-        foldersProvider.hasProblemCache(targetFolderId);
-
-    // 캐시가 없으면 로딩 다이얼로그 표시
-    if (!hasCache && mounted) {
-      LoadingDialog.show(context, '공책 불러오는 중...');
-    }
-
     try {
       // 첫 페이지 로드 (하위 폴더와 문제) - 캐시 우선 사용
       await Future.wait([
@@ -179,11 +170,6 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
         _loadMoreProblemsLocal(targetFolderId),
       ]);
     } finally {
-      // 로딩 다이얼로그 숨기기 (캐시가 없었던 경우에만)
-      if (!hasCache && mounted) {
-        LoadingDialog.hide(context);
-      }
-
       // 초기 로딩 완료
       if (mounted) {
         setState(() {

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -1416,11 +1416,19 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
     final foldersProvider =
         Provider.of<FoldersProvider>(context, listen: false);
 
-    // 폴더 업데이트 (서버 + 메타데이터 갱신 + 목적지 폴더 캐시 갱신은 updateFolder에서 처리)
+    // 폴더 업데이트 (서버 + 메타데이터 갱신)
     await foldersProvider.updateFolder(
         folder.folderName, folder.folderId, newParentFolderId);
 
-    // 로컬 데이터 새로고침 (이동한 폴더가 목록에서 사라지도록)
+    // 출발지 폴더 캐시 갱신 (이동한 폴더가 목록에서 사라지도록)
+    if (_currentFolder != null) {
+      await foldersProvider.refreshFolder(_currentFolder!.folderId);
+    }
+
+    // 목적지 폴더 캐시 갱신 (옮긴 폴더가 목적지에 나타나도록)
+    await foldersProvider.refreshFolder(newParentFolderId);
+
+    // 로컬 데이터 새로고침
     await _loadFolderData();
 
     if (mounted) {
@@ -1446,11 +1454,21 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
 
     final problemsProvider =
         Provider.of<ProblemsProvider>(context, listen: false);
+    final foldersProvider =
+        Provider.of<FoldersProvider>(context, listen: false);
 
     // 문제 업데이트 (서버 + ProblemsProvider 캐시 갱신)
     await problemsProvider.updateProblem(problemRegisterModel);
 
-    // 로컬 데이터 새로고침 (이동한 문제가 목록에서 사라지도록)
+    // 출발지 폴더 캐시 갱신 (이동한 문제가 목록에서 사라지도록)
+    if (_currentFolder != null) {
+      await foldersProvider.refreshFolder(_currentFolder!.folderId);
+    }
+
+    // 목적지 폴더 캐시 갱신 (옮긴 문제가 목적지에 나타나도록)
+    await foldersProvider.refreshFolder(problemRegisterModel.folderId!);
+
+    // 로컬 데이터 새로고침
     await _loadFolderData();
 
     if (mounted) {

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -849,10 +849,8 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
               var currentProblems = _localProblems;
               final isLoadingMore = _isLoadingSubfolders || _isLoadingProblems;
 
-              // 로딩 중이면 로딩 인디케이터 표시
-              if (currentSubfolders.isEmpty &&
-                  currentProblems.isEmpty &&
-                  isLoadingMore) {
+              // 초기 로딩 중이면 로딩 인디케이터 표시
+              if (_isInitialLoading) {
                 return const Center(
                   child: CircularProgressIndicator(),
                 );

--- a/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
+++ b/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
@@ -355,6 +355,21 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
         );
 
         log('백그라운드 이미지 업로드 완료 - problemId: $problemId');
+
+        // 이미지 업로드 완료 후 폴더 캐시 새로고침 (썸네일 업데이트)
+        if (mounted) {
+          final foldersProvider = Provider.of<FoldersProvider>(context, listen: false);
+          if (_selectedFolderId != null) {
+            await foldersProvider.refreshFolder(_selectedFolderId!);
+          } else {
+            // 루트 폴더 갱신 (타임스탬프 업데이트됨)
+            final rootFolder = foldersProvider.rootFolder;
+            if (rootFolder != null) {
+              await foldersProvider.refreshFolder(rootFolder.folderId);
+            }
+          }
+          log('폴더 캐시 새로고침 완료 - 썸네일 업데이트됨');
+        }
       } catch (e, stackTrace) {
         log('백그라운드 이미지 업로드 실패 - problemId: $problemId');
         log('에러: $e');

--- a/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
+++ b/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
@@ -290,22 +290,22 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
     await problemsProvider.updateProblemCount(1);
     await problemsProvider.requestReview(context);
 
-    // 2. 폴더 갱신 (_selectedFolderId가 null이면 루트 폴더를 갱신)
+    // 2. 유저 정보 갱신 (경험치 업데이트)
+    await Provider.of<UserProvider>(context, listen: false).fetchUserInfo();
+
+    // 3. 폴더 갱신 (화면 전환 전에 먼저 캐시 삭제 및 타임스탬프 업데이트)
     final foldersProvider = Provider.of<FoldersProvider>(context, listen: false);
     if (_selectedFolderId != null) {
       await foldersProvider.refreshFolder(_selectedFolderId!);
     } else {
-      // 루트 폴더 갱신
+      // 루트 폴더 갱신 (타임스탬프 업데이트됨)
       final rootFolder = foldersProvider.rootFolder;
       if (rootFolder != null) {
         await foldersProvider.refreshFolder(rootFolder.folderId);
       }
     }
 
-    // 3. 유저 정보 갱신 (경험치 업데이트)
-    await Provider.of<UserProvider>(context, listen: false).fetchUserInfo();
-
-    // 4. 화면 초기화 및 이동
+    // 4. 화면 초기화 및 이동 (이제 DirectoryScreen이 mount되면서 변경된 타임스탬프를 감지)
     Provider.of<ScreenIndexProvider>(context, listen: false)
         .setSelectedIndex(0);
 


### PR DESCRIPTION
## ✔️ 연관 이슈

## 📝 작업 내용

> 무한 스크롤 기능 도입 이후 발생한 문제들을 해결했습니다. UX를 일부 개선했습니다.

- 폴더 조회 시 데이터를 캐싱하지 않고, 매번 서버에 조회 요청을 보내던 문제 해결
- 캐싱 기능으로 인해 화면 동기화가 정상적으로 작동하지 않던 문제 해결
- 데이터 조회 로딩 시, 로딩 애니메이션이 출력되도록 개선

### 스크린샷 (선택)
