### PR TITLE
[Feat] 태블릿 화면 디자인 개선

### DIFF
--- a/lib/Module/Image/ImagePickerHandler.dart
+++ b/lib/Module/Image/ImagePickerHandler.dart
@@ -105,13 +105,25 @@ class ImagePickerHandler {
 
   void showImagePicker(BuildContext context, Function(XFile?) onImagePicked,
       {Function(List<XFile>)? onMultipleImagesPicked}) {
+    final openTime = DateTime.now();
     showModalBottomSheet(
       backgroundColor: Colors.white,
       context: context,
+      isDismissible: false,
       builder: (BuildContext context) {
         final themeProvider = Provider.of<ThemeHandler>(context, listen: false);
 
-        return SingleChildScrollView(
+        return TapRegion(
+          onTapOutside: (_) {
+            // Workaround for iPadOS 26.1 bug: https://github.com/flutter/flutter/issues/177992
+            if (DateTime.now().difference(openTime) < const Duration(milliseconds: 500)) {
+              return;
+            }
+            if (Navigator.canPop(context)) {
+              Navigator.pop(context);
+            }
+          },
+          child: SingleChildScrollView(
           child: Padding(
             padding: const EdgeInsets.symmetric(
                 vertical: 20.0, horizontal: 10.0), // 기존 모달과 동일한 여백 적용
@@ -199,6 +211,7 @@ class ImagePickerHandler {
                   ),
               ],
             ),
+          ),
           ),
         );
       },

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -238,19 +238,32 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
   void _showUserGuideModal() async {
     FirebaseAnalytics.instance.logEvent(name: 'show_user_guide_modal');
 
+    final openTime = DateTime.now();
     await showModalBottomSheet(
       context: context,
       isScrollControlled: true, // 스크롤 가능 모달 설정
       backgroundColor: Colors.transparent, // 투명 배경
+      isDismissible: false,
       builder: (BuildContext context) {
-        return FractionallySizedBox(
-          heightFactor: 0.6, // 화면 높이의 50% 차지
-          child: UserGuideScreen(
-            onFinish: () {
-              Navigator.of(context).pop(); // 모달 닫기
+        return TapRegion(
+            onTapOutside: (_) {
+              // Workaround for iPadOS 26.1 bug: https://github.com/flutter/flutter/issues/177992
+              if (DateTime.now().difference(openTime) <
+                  const Duration(milliseconds: 500)) {
+                return;
+              }
+              if (Navigator.canPop(context)) {
+                Navigator.pop(context);
+              }
             },
-          ),
-        );
+            child: FractionallySizedBox(
+              heightFactor: 0.6, // 화면 높이의 50% 차지
+              child: UserGuideScreen(
+                onFinish: () {
+                  Navigator.of(context).pop(); // 모달 닫기
+                },
+              ),
+            ));
       },
     );
   }
@@ -379,104 +392,120 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
     FirebaseAnalytics.instance
         .logEvent(name: 'directory_Screen_action_dialog_click');
 
+    final openTime = DateTime.now();
     showModalBottomSheet(
       backgroundColor: Colors.white,
       context: context,
+      isDismissible: false,
       builder: (context) {
-        return SingleChildScrollView(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(
-                vertical: 20.0, horizontal: 10.0), // 패딩 추가
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 20.0), // 타이틀 아래 여백 추가
-                  child: StandardText(
-                    text: '공책 편집하기', // 타이틀 텍스트
-                    fontSize: 20,
-                    color: themeProvider.primaryColor,
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 10.0),
-                  child: ListTile(
-                    leading: const Icon(Icons.add, color: Colors.black),
-                    title: const StandardText(
-                      text: '공책 추가하기',
-                      fontSize: 16,
-                      color: Colors.black,
+        return TapRegion(
+          onTapOutside: (_) {
+            // Workaround for iPadOS 26.1 bug: https://github.com/flutter/flutter/issues/177992
+            if (DateTime.now().difference(openTime) <
+                const Duration(milliseconds: 500)) {
+              return;
+            }
+            if (Navigator.canPop(context)) {
+              Navigator.pop(context);
+            }
+          },
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                  vertical: 20.0, horizontal: 10.0), // 패딩 추가
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Padding(
+                    padding:
+                        const EdgeInsets.only(bottom: 20.0), // 타이틀 아래 여백 추가
+                    child: StandardText(
+                      text: '공책 편집하기', // 타이틀 텍스트
+                      fontSize: 20,
+                      color: themeProvider.primaryColor,
                     ),
-                    onTap: () {
-                      Navigator.pop(context);
-                      FirebaseAnalytics.instance.logEvent(
-                          name: 'directory_create_folder_button_click');
-                      _showCreateFolderDialog();
-                    },
                   ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 10.0), // 텍스트 간격 조정
-                  child: ListTile(
-                    leading: const Icon(Icons.edit, color: Colors.black),
-                    title: const StandardText(
-                      text: '공책 이름 수정하기',
-                      fontSize: 16,
-                      color: Colors.black,
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 10.0),
+                    child: ListTile(
+                      leading: const Icon(Icons.add, color: Colors.black),
+                      title: const StandardText(
+                        text: '공책 추가하기',
+                        fontSize: 16,
+                        color: Colors.black,
+                      ),
+                      onTap: () {
+                        Navigator.pop(context);
+                        FirebaseAnalytics.instance.logEvent(
+                            name: 'directory_create_folder_button_click');
+                        _showCreateFolderDialog();
+                      },
                     ),
-                    onTap: () {
-                      Navigator.pop(context);
-
-                      FirebaseAnalytics.instance
-                          .logEvent(name: 'directory_rename_button_click');
-
-                      _showRenameFolderDialog(foldersProvider);
-                    },
                   ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 10.0), // 텍스트 간격 조정
-                  child: ListTile(
-                    leading: const Icon(Icons.folder_open, color: Colors.black),
-                    title: const StandardText(
-                      text: '공책 위치 변경하기',
-                      fontSize: 16,
-                      color: Colors.black,
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 10.0), // 텍스트 간격 조정
+                    child: ListTile(
+                      leading: const Icon(Icons.edit, color: Colors.black),
+                      title: const StandardText(
+                        text: '공책 이름 수정하기',
+                        fontSize: 16,
+                        color: Colors.black,
+                      ),
+                      onTap: () {
+                        Navigator.pop(context);
+
+                        FirebaseAnalytics.instance
+                            .logEvent(name: 'directory_rename_button_click');
+
+                        _showRenameFolderDialog(foldersProvider);
+                      },
                     ),
-                    onTap: () {
-                      Navigator.pop(context);
-
-                      FirebaseAnalytics.instance
-                          .logEvent(name: 'directory_path_change_button_click');
-
-                      _showMoveFolderDialog(foldersProvider);
-                    },
                   ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 10.0), // 텍스트 간격 조정
-                  child: ListTile(
-                    leading:
-                        const Icon(Icons.delete_forever, color: Colors.red),
-                    title: const StandardText(
-                      text: '공책 편집하기',
-                      fontSize: 16,
-                      color: Colors.red,
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 10.0), // 텍스트 간격 조정
+                    child: ListTile(
+                      leading:
+                          const Icon(Icons.folder_open, color: Colors.black),
+                      title: const StandardText(
+                        text: '공책 위치 변경하기',
+                        fontSize: 16,
+                        color: Colors.black,
+                      ),
+                      onTap: () {
+                        Navigator.pop(context);
+
+                        FirebaseAnalytics.instance.logEvent(
+                            name: 'directory_path_change_button_click');
+
+                        _showMoveFolderDialog(foldersProvider);
+                      },
                     ),
-                    onTap: () {
-                      Navigator.pop(context);
-
-                      // 편집 모드 활성화
-                      setState(() {
-                        _isSelectionMode = true;
-                      });
-
-                      FirebaseAnalytics.instance
-                          .logEvent(name: 'directory_enable_edit_mode');
-                    },
                   ),
-                ),
-              ],
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 10.0), // 텍스트 간격 조정
+                    child: ListTile(
+                      leading:
+                          const Icon(Icons.delete_forever, color: Colors.red),
+                      title: const StandardText(
+                        text: '공책 편집하기',
+                        fontSize: 16,
+                        color: Colors.red,
+                      ),
+                      onTap: () {
+                        Navigator.pop(context);
+
+                        // 편집 모드 활성화
+                        setState(() {
+                          _isSelectionMode = true;
+                        });
+
+                        FirebaseAnalytics.instance
+                            .logEvent(name: 'directory_enable_edit_mode');
+                      },
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         );
@@ -628,9 +657,8 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
                 focusedBorder: const OutlineInputBorder(
                   borderSide: BorderSide(color: Colors.black, width: 1.5),
                 ),
-                contentPadding: const EdgeInsets.symmetric(
-                    vertical: 12,
-                    horizontal: 16),
+                contentPadding:
+                    const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
               ),
             ),
           ),

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -628,9 +628,9 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
                 focusedBorder: const OutlineInputBorder(
                   borderSide: BorderSide(color: Colors.black, width: 1.5),
                 ),
-                contentPadding: EdgeInsets.symmetric(
-                    vertical: screenHeight * 0.02,
-                    horizontal: screenWidth * 0.03),
+                contentPadding: const EdgeInsets.symmetric(
+                    vertical: 12,
+                    horizontal: 16),
               ),
             ),
           ),

--- a/lib/Screen/PracticeNote/PracticeDetailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeDetailScreen.dart
@@ -75,11 +75,23 @@ class PracticeDetailScreen extends StatelessWidget {
   void _showBottomSheet(BuildContext context) async {
     final themeProvider = Provider.of<ThemeHandler>(context, listen: false);
 
+    final openTime = DateTime.now();
     showModalBottomSheet(
       backgroundColor: Colors.white,
       context: context,
+      isDismissible: false,
       builder: (context) {
-        return SingleChildScrollView(
+        return TapRegion(
+          onTapOutside: (_) {
+            // Workaround for iPadOS 26.1 bug: https://github.com/flutter/flutter/issues/177992
+            if (DateTime.now().difference(openTime) < const Duration(milliseconds: 500)) {
+              return;
+            }
+            if (Navigator.canPop(context)) {
+              Navigator.pop(context);
+            }
+          },
+          child: SingleChildScrollView(
           child: Padding(
             padding: const EdgeInsets.symmetric(
                 vertical: 20.0, horizontal: 10.0), // 패딩 추가
@@ -136,6 +148,7 @@ class PracticeDetailScreen extends StatelessWidget {
               ],
             ),
           ),
+        ),
         );
       },
     );

--- a/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
@@ -140,11 +140,23 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
   void _showBottomSheet() {
     final themeProvider = Provider.of<ThemeHandler>(context, listen: false);
 
+    final openTime = DateTime.now();
     showModalBottomSheet(
       backgroundColor: Colors.white,
       context: context,
+      isDismissible: false,
       builder: (context) {
-        return SingleChildScrollView(
+        return TapRegion(
+          onTapOutside: (_) {
+            // Workaround for iPadOS 26.1 bug: https://github.com/flutter/flutter/issues/177992
+            if (DateTime.now().difference(openTime) < const Duration(milliseconds: 500)) {
+              return;
+            }
+            if (Navigator.canPop(context)) {
+              Navigator.pop(context);
+            }
+          },
+          child: SingleChildScrollView(
           child: Padding(
             padding: const EdgeInsets.symmetric(
                 vertical: 20.0, horizontal: 10.0), // 패딩 추가
@@ -203,6 +215,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
               ],
             ),
           ),
+        ),
         );
       },
     );

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -473,15 +473,27 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
   }
 
   void _showTimePickerBottomSheet(BuildContext context) {
+    final openTime = DateTime.now();
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.white, // 바텀시트 배경을 흰색으로
+      isDismissible: false,
       shape: const RoundedRectangleBorder(
         // 모서리를 살짝 둥글게
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
       builder: (_) {
-        return Container(
+        return TapRegion(
+          onTapOutside: (_) {
+            // Workaround for iPadOS 26.1 bug: https://github.com/flutter/flutter/issues/177992
+            if (DateTime.now().difference(openTime) < const Duration(milliseconds: 500)) {
+              return;
+            }
+            if (Navigator.canPop(context)) {
+              Navigator.pop(context);
+            }
+          },
+          child: Container(
           height: 250,
           padding: const EdgeInsets.all(16),
           decoration: const BoxDecoration(
@@ -531,6 +543,7 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
               ),
             ],
           ),
+        ),
         );
       },
     );

--- a/lib/Screen/ProblemDetail/ProblemDetailScreen.dart
+++ b/lib/Screen/ProblemDetail/ProblemDetailScreen.dart
@@ -155,11 +155,23 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
     FirebaseAnalytics.instance
         .logEvent(name: 'problem_detail_screen_action_dialog_button_click');
 
+    final openTime = DateTime.now();
     showModalBottomSheet(
       backgroundColor: Colors.white,
       context: context,
+      isDismissible: false,
       builder: (context) {
-        return SingleChildScrollView(
+        return TapRegion(
+          onTapOutside: (_) {
+            // Workaround for iPadOS 26.1 bug: https://github.com/flutter/flutter/issues/177992
+            if (DateTime.now().difference(openTime) < const Duration(milliseconds: 500)) {
+              return;
+            }
+            if (Navigator.canPop(context)) {
+              Navigator.pop(context);
+            }
+          },
+          child: SingleChildScrollView(
           child: Padding(
             padding: const EdgeInsets.symmetric(
                 vertical: 20.0, horizontal: 10.0), // 패딩 추가
@@ -273,6 +285,7 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
               ],
             ),
           ),
+        ),
         );
       },
     );

--- a/lib/Screen/ProblemDetail/Widget/ImageGallerySection.dart
+++ b/lib/Screen/ProblemDetail/Widget/ImageGallerySection.dart
@@ -36,8 +36,17 @@ class _ImageGallerySectionState extends State<ImageGallerySection> {
   @override
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.of(context).size.width;
-    // 실제 화면 너비의 90%를 이미지로 사용
-    final imageHeight = screenWidth * 0.9;
+    final screenHeight = MediaQuery.of(context).size.height;
+
+    // 화면 크기에 따른 이미지 높이 계산
+    double imageHeight;
+    if (screenWidth > 600) {
+      // 태블릿: 화면 높이의 40%로 제한 (최대 500)
+      imageHeight = (screenHeight * 0.6).clamp(300.0, 500.0);
+    } else {
+      // 모바일: 화면 너비의 90%
+      imageHeight = screenWidth * 0.9;
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/Screen/ProblemRegister/ProblemRegisterScreen.dart
+++ b/lib/Screen/ProblemRegister/ProblemRegisterScreen.dart
@@ -39,45 +39,37 @@ class _ProblemRegisterScreenState extends State<ProblemRegisterScreen> {
           fontSize: 20,
         ),
       ),
-      body: Stack(
-        children: [
-          SingleChildScrollView(
-            padding: const EdgeInsets.only(
-              left: 20,
-              right: 20,
-              top: 20,
-              bottom: 100, // Space for fixed buttons
+      body: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
+        child: ProblemRegisterTemplate(
+          key: _templateKey,
+          problemModel: widget.problemModel,
+          isEditMode: widget.isEditMode,
+        ),
+      ),
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          boxShadow: [
+            BoxShadow(
+              color: Colors.grey.withOpacity(0.2),
+              blurRadius: 10,
+              offset: const Offset(0, -2),
             ),
-            child: ProblemRegisterTemplate(
-              key: _templateKey,
-              problemModel: widget.problemModel,
-              isEditMode: widget.isEditMode,
-            ),
-          ),
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0,
-            child: Container(
-              decoration: BoxDecoration(
-                color: Colors.white,
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.grey.withOpacity(0.2),
-                    blurRadius: 10,
-                    offset: const Offset(0, -2),
-                  ),
-                ],
-              ),
-              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-              child: ActionButtons(
-                isEdit: widget.isEditMode,
-                onCancel: () => _templateKey.currentState?.resetAll(),
-                onSubmit: () => _templateKey.currentState?.submit(),
-              ),
-            ),
-          ),
-        ],
+          ],
+        ),
+        padding: EdgeInsets.only(
+          left: 20,
+          right: 20,
+          top: 12,
+          bottom: MediaQuery.of(context).padding.bottom + 12,
+        ),
+        child: ActionButtons(
+          isEdit: widget.isEditMode,
+          onCancel: () => _templateKey.currentState?.resetAll(),
+          onSubmit: () => _templateKey.currentState?.submit(),
+        ),
       ),
     );
   }

--- a/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
+++ b/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
@@ -91,6 +91,7 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
   @override
   Widget build(BuildContext context) {
     final isWide = MediaQuery.of(context).size.width >= 600;
+    final spacing = isWide ? 50.0 : 30.0; // 태블릿: 50px, 모바일: 30px
 
     return GestureDetector(
         behavior: HitTestBehavior.translucent,
@@ -103,19 +104,19 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
                 selectedDate: _selectedDate,
                 onDateChanged: (d) => setState(() => _selectedDate = d),
               ),
-              const SizedBox(height: 30),
+              SizedBox(height: spacing),
               FolderPickerWidget(
                 selectedId: _selectedFolderId,
                 onPicked: (id) => setState(() => _selectedFolderId = id),
               ),
-              const SizedBox(height: 30),
+              SizedBox(height: spacing),
               LabeledTextField(
                 label: '제목',
                 hintText: '오답노트의 제목을 작성해주세요!',
                 icon: Icons.info,
                 controller: _titleCtrl,
               ),
-              const SizedBox(height: 30),
+              SizedBox(height: spacing),
               LabeledTextField(
                 label: '메모',
                 controller: _memoCtrl,
@@ -123,7 +124,7 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
                 hintText: '기록하고 싶은 내용을 간단하게 작성해주세요!',
                 maxLines: 3,
               ),
-              const SizedBox(height: 30),
+              SizedBox(height: spacing),
               if (isWide)
                 Row(
                   children: [


### PR DESCRIPTION
## ✔️ 연관 이슈

## 📝 작업 내용

> 태블릿, 노트북 화면의 디자인을 개선했습니다.

- 오답노트 상세 페이지 개선
  - 이미지 크기 축소
- 오답노트 등록 페이지 
  - 항상 스크롤이 가능하도록 개선
  - 항목 간 세로 여백 증가

- iOS 26.1 버그 수정
  - 다이얼로그가 즉시 사라지는 버그 해결

### 스크린샷 (선택)

<img width="1884" height="1460" alt="image" src="https://github.com/user-attachments/assets/68a10b86-a88f-4f27-b6f3-b91a3c798c42" />
<img width="1884" height="1460" alt="image" src="https://github.com/user-attachments/assets/48442f63-9a62-46a1-915c-271ee235e9c1" />
