### PR TITLE
[Fix] 복습노트 조회 시, 데이터를 캐싱해 사용할 수 있도록 수정

### DIFF
--- a/lib/Module/Util/FolderPickerDialog.dart
+++ b/lib/Module/Util/FolderPickerDialog.dart
@@ -257,22 +257,28 @@ class _FolderPickerDialogState extends State<FolderPickerDialog> {
           leading: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              // 확장/축소 버튼
-              node.isLoading
-                  ? const SizedBox(
-                      width: 24,
-                      height: 24,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : IconButton(
-                      icon: Icon(
-                        node.isExpanded
-                            ? Icons.expand_more
-                            : Icons.chevron_right,
+              // 확장/축소 버튼 (항상 같은 크기 유지)
+              SizedBox(
+                width: 48, // IconButton의 기본 크기
+                height: 48,
+                child: node.isLoading
+                    ? const Center(
+                        child: SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                      )
+                    : IconButton(
+                        icon: Icon(
+                          node.isExpanded
+                              ? Icons.expand_more
+                              : Icons.chevron_right,
+                        ),
+                        color: themeProvider.primaryColor,
+                        onPressed: () => _toggleFolder(node),
                       ),
-                      color: themeProvider.primaryColor,
-                      onPressed: () => _toggleFolder(node),
-                    ),
+              ),
               // 폴더 아이콘
               SvgPicture.asset(
                 NoteIconHandler.getNoteIcon(level),

--- a/lib/Screen/PracticeNote/PracticeCompletionScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeCompletionScreen.dart
@@ -100,8 +100,10 @@ class PracticeCompletionScreen extends StatelessWidget {
         child: ElevatedButton(
           onPressed: () async {
             await practiceProvider.addPracticeCount(practiceId);
-            Navigator.of(context).pop();
-            Navigator.of(context).pop();
+            // 2번 pop: PracticeCompletionScreen -> PracticeDetailScreen -> PracticeThumbnailScreen
+            // 두 번째 pop에서 true를 반환하여 썸네일 업데이트 신호 전달
+            Navigator.of(context).pop(); // PracticeCompletionScreen 닫기
+            Navigator.of(context).pop(true); // PracticeDetailScreen 닫으면서 true 반환
             SnackBarDialog.showSnackBar(
               context: context,
               message: '복습을 완료했습니다!',

--- a/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
@@ -484,16 +484,19 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
     await practiceProvider.moveToPractice(practiceId);
     LoadingDialog.hide(context);
 
-    Navigator.push(
+    final result = await Navigator.push<bool>(
       context,
       MaterialPageRoute(
         builder: (context) => PracticeDetailScreen(
             practice: practiceProvider.currentPracticeNote!),
       ),
-    ).then((_) {
-      // 복습 상세 화면에서 돌아왔을 때 최신 데이터 다시 조회
-      _refreshPracticeThumbnails();
-    });
+    );
+
+    // 복습을 완료한 경우(result == true)에만 해당 썸네일 업데이트
+    if (result == true) {
+      await practiceProvider.updateSinglePracticeThumbnail(practiceId);
+    }
+    // 그 외의 경우(조회만 한 경우)는 캐시 유지
   }
 
   BoxDecoration _buildBoxDecoration(


### PR DESCRIPTION
## ✔️ 연관 이슈

## 📝 작업 내용

> 복습 노트 조회 시, 데이터를 캐싱하지 않고 매번 조회 요청을 보내 서버 트래픽이 증가하는 문제 발생

- 복습 노트 조회 시, 데이터를 캐싱하도록 개선
- 수정, 삭제 등의 요청 발생 시, 데이터를 fetch 하는 로직 추가

> 오답노트 작성 > 폴더 선택 화면에서 폴더 조회 로딩 시, 아이콘이 깜빡깜빡 하는 문제 발생

- 오답노트 작성 > 폴더 선택 화면 디자인 버그 수정

### 스크린샷 (선택)
