### PR TITLE
[Design] 태블릿 화면 오답노트 상세 페이지 디자인 개선

### DIFF
--- a/lib/Module/Util/FolderPickerWidget.dart
+++ b/lib/Module/Util/FolderPickerWidget.dart
@@ -32,6 +32,8 @@ class _FolderPickerWidgetState extends State<FolderPickerWidget> {
   Widget build(BuildContext context) {
     final theme = Provider.of<ThemeHandler>(context);
     final foldersProvider = Provider.of<FoldersProvider>(context);
+    final screenWidth = MediaQuery.of(context).size.width;
+    final selectorWidth = screenWidth >= 600 ? 210.0 : 170.0;
 
     // 폴더 데이터가 로드될 때까지 기다림
     if (foldersProvider.folders.isEmpty) {
@@ -109,44 +111,44 @@ class _FolderPickerWidgetState extends State<FolderPickerWidget> {
               color: Colors.black87,
             ),
           ),
-          GestureDetector(
-            onTap: () async {
-              final id =
-                  await FolderPickerWidget.showPicker(context, widget.selectedId);
-              widget.onPicked(id);
-            },
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey[300]!, width: 1),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    Icons.folder_open,
-                    color: theme.primaryColor,
-                    size: 18,
-                  ),
-                  const SizedBox(width: 8),
-                  ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 100),
-                    child: StandardText(
-                      text: name ?? '책장',
-                      fontSize: 14,
-                      color: Colors.black87,
-                      overflow: TextOverflow.ellipsis,
+          SizedBox(
+            width: selectorWidth,
+            child: GestureDetector(
+              onTap: () async {
+                final id = await FolderPickerWidget.showPicker(
+                    context, widget.selectedId);
+                widget.onPicked(id);
+              },
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.grey[300]!, width: 1),
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: StandardText(
+                          text: name ?? '책장',
+                          fontSize: 14,
+                          color: Colors.black87,
+                          overflow: TextOverflow.ellipsis,
+                          textAlign: TextAlign.right,
+                        ),
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: 4),
-                  Icon(
-                    Icons.arrow_drop_down,
-                    color: Colors.grey[600],
-                    size: 20,
-                  ),
-                ],
+                    const SizedBox(width: 4),
+                    Icon(
+                      Icons.arrow_drop_down,
+                      color: Colors.grey[600],
+                      size: 20,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -36,6 +36,7 @@ class DirectoryScreen extends StatefulWidget {
 }
 
 class _DirectoryScreenState extends State<DirectoryScreen> {
+  static const double _dialogMaxWidth = 420;
   bool modalShown = false;
   bool _isSelectionMode = false; // 선택 모드 활성화 여부
   final List<int> _selectedFolderIds = []; // 선택된 폴더 ID 리스트
@@ -805,72 +806,74 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
     await showDialog(
       context: context,
       builder: (context) {
-        return Dialog(
-          backgroundColor: Colors.white,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-          child: Container(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                // 헤더
-                Row(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.all(8),
-                      decoration: BoxDecoration(
-                        color: Colors.orange.withOpacity(0.1),
-                        borderRadius: BorderRadius.circular(8),
+        return _buildPhoneWidthDialog(
+          Dialog(
+            backgroundColor: Colors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Container(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // 헤더
+                  Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: Colors.orange.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: const Icon(
+                          Icons.warning,
+                          color: Colors.orange,
+                          size: 20,
+                        ),
                       ),
-                      child: const Icon(
-                        Icons.warning,
-                        color: Colors.orange,
-                        size: 20,
+                      const SizedBox(width: 12),
+                      const StandardText(
+                        text: '공책 위치 변경 불가',
+                        fontSize: 18,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.black87,
                       ),
-                    ),
-                    const SizedBox(width: 12),
-                    const StandardText(
-                      text: '공책 위치 변경 불가',
-                      fontSize: 18,
-                      fontWeight: FontWeight.w600,
-                      color: Colors.black87,
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 20),
-                // 내용
-                const StandardText(
-                  text: '책장의 위치를 변경할 수 없습니다.',
-                  fontSize: 15,
-                  color: Colors.black87,
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 24),
-                // 버튼
-                SizedBox(
-                  width: double.infinity,
-                  child: TextButton(
-                    onPressed: () {
-                      Navigator.pop(context);
-                    },
-                    style: TextButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 8),
-                      backgroundColor: themeProvider.primaryColor,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  // 내용
+                  const StandardText(
+                    text: '책장의 위치를 변경할 수 없습니다.',
+                    fontSize: 15,
+                    color: Colors.black87,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 24),
+                  // 버튼
+                  SizedBox(
+                    width: double.infinity,
+                    child: TextButton(
+                      onPressed: () {
+                        Navigator.pop(context);
+                      },
+                      style: TextButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 12, vertical: 8),
+                        backgroundColor: themeProvider.primaryColor,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8),
+                        ),
                       ),
-                    ),
-                    child: const StandardText(
-                      text: '확인',
-                      fontSize: 14,
-                      color: Colors.white,
+                      child: const StandardText(
+                        text: '확인',
+                        fontSize: 14,
+                        color: Colors.white,
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         );
@@ -914,129 +917,131 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
               Navigator.pop(dialogContext);
             }
           },
-          child: Dialog(
-            backgroundColor: Colors.white,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(16),
-            ),
-            child: Container(
-              padding: const EdgeInsets.all(24),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // 헤더
-                  Row(
-                    children: [
-                      Container(
-                        padding: const EdgeInsets.all(8),
-                        decoration: BoxDecoration(
-                          color: themeProvider.primaryColor.withOpacity(0.1),
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Icon(
-                          Icons.edit,
-                          color: themeProvider.primaryColor,
-                          size: 20,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      StandardText(
-                        text: dialogTitle,
-                        fontSize: 20,
-                        fontWeight: FontWeight.w600,
-                        color: Colors.black87,
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 24),
-                  // 입력 필드
-                  TextField(
-                    controller: folderNameController,
-                    autofocus: true,
-                    style: standardTextStyle.copyWith(
-                      color: Colors.black87,
-                      fontSize: 15,
-                    ),
-                    decoration: InputDecoration(
-                      hintText: '공책 이름을 입력하세요',
-                      hintStyle: standardTextStyle.copyWith(
-                        color: Colors.grey[400],
-                        fontSize: 14,
-                      ),
-                      fillColor: Colors.grey[50],
-                      filled: true,
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide:
-                            BorderSide(color: Colors.grey[300]!, width: 1),
-                      ),
-                      enabledBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide:
-                            BorderSide(color: Colors.grey[300]!, width: 1),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: BorderSide(
-                          color: themeProvider.primaryColor.withOpacity(0.5),
-                          width: 2,
-                        ),
-                      ),
-                      contentPadding: const EdgeInsets.symmetric(
-                        vertical: 16,
-                        horizontal: 16,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 24),
-                  // 액션 버튼
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      TextButton(
-                        onPressed: () {
-                          Navigator.pop(dialogContext);
-                        },
-                        style: TextButton.styleFrom(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 12, vertical: 8),
-                          backgroundColor: Colors.grey[100],
-                          shape: RoundedRectangleBorder(
+          child: _buildPhoneWidthDialog(
+            Dialog(
+              backgroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Container(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 헤더
+                    Row(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.all(8),
+                          decoration: BoxDecoration(
+                            color: themeProvider.primaryColor.withOpacity(0.1),
                             borderRadius: BorderRadius.circular(8),
                           ),
+                          child: Icon(
+                            Icons.edit,
+                            color: themeProvider.primaryColor,
+                            size: 20,
+                          ),
                         ),
-                        child: const StandardText(
-                          text: '취소',
-                          fontSize: 14,
+                        const SizedBox(width: 12),
+                        StandardText(
+                          text: dialogTitle,
+                          fontSize: 20,
+                          fontWeight: FontWeight.w600,
                           color: Colors.black87,
                         ),
+                      ],
+                    ),
+                    const SizedBox(height: 24),
+                    // 입력 필드
+                    TextField(
+                      controller: folderNameController,
+                      autofocus: true,
+                      style: standardTextStyle.copyWith(
+                        color: Colors.black87,
+                        fontSize: 15,
                       ),
-                      const SizedBox(width: 8),
-                      TextButton(
-                        onPressed: () async {
-                          if (folderNameController.text.isNotEmpty) {
-                            onFolderNameSubmitted(folderNameController.text);
-                            Navigator.pop(dialogContext);
-                          }
-                        },
-                        style: TextButton.styleFrom(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 12, vertical: 8),
-                          backgroundColor: themeProvider.primaryColor,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(8),
+                      decoration: InputDecoration(
+                        hintText: '공책 이름을 입력하세요',
+                        hintStyle: standardTextStyle.copyWith(
+                          color: Colors.grey[400],
+                          fontSize: 14,
+                        ),
+                        fillColor: Colors.grey[50],
+                        filled: true,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide:
+                              BorderSide(color: Colors.grey[300]!, width: 1),
+                        ),
+                        enabledBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide:
+                              BorderSide(color: Colors.grey[300]!, width: 1),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide(
+                            color: themeProvider.primaryColor.withOpacity(0.5),
+                            width: 2,
                           ),
                         ),
-                        child: const StandardText(
-                          text: '확인',
-                          fontSize: 14,
-                          color: Colors.white,
+                        contentPadding: const EdgeInsets.symmetric(
+                          vertical: 16,
+                          horizontal: 16,
                         ),
                       ),
-                    ],
-                  ),
-                ],
+                    ),
+                    const SizedBox(height: 24),
+                    // 액션 버튼
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        TextButton(
+                          onPressed: () {
+                            Navigator.pop(dialogContext);
+                          },
+                          style: TextButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 12, vertical: 8),
+                            backgroundColor: Colors.grey[100],
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
+                          child: const StandardText(
+                            text: '취소',
+                            fontSize: 14,
+                            color: Colors.black87,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        TextButton(
+                          onPressed: () async {
+                            if (folderNameController.text.isNotEmpty) {
+                              onFolderNameSubmitted(folderNameController.text);
+                              Navigator.pop(dialogContext);
+                            }
+                          },
+                          style: TextButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 12, vertical: 8),
+                            backgroundColor: themeProvider.primaryColor,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
+                          child: const StandardText(
+                            text: '확인',
+                            fontSize: 14,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -1566,97 +1571,108 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
 
     showDialog(
       context: context,
-      builder: (dialogContext) => Dialog(
-        backgroundColor: Colors.white,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
-        ),
-        child: Container(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              // 헤더
-              Row(
-                children: [
-                  Container(
-                    padding: const EdgeInsets.all(8),
-                    decoration: BoxDecoration(
-                      color: Colors.red.withOpacity(0.1),
-                      borderRadius: BorderRadius.circular(8),
+      builder: (dialogContext) => _buildPhoneWidthDialog(
+        Dialog(
+          backgroundColor: Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Container(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // 헤더
+                Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(8),
+                      decoration: BoxDecoration(
+                        color: Colors.red.withOpacity(0.1),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: const Icon(
+                        Icons.delete_forever,
+                        color: Colors.red,
+                        size: 20,
+                      ),
                     ),
-                    child: const Icon(
-                      Icons.delete_forever,
-                      color: Colors.red,
-                      size: 20,
+                    const SizedBox(width: 12),
+                    const StandardText(
+                      text: '삭제 확인',
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.black87,
                     ),
-                  ),
-                  const SizedBox(width: 12),
-                  const StandardText(
-                    text: '삭제 확인',
-                    fontSize: 18,
-                    fontWeight: FontWeight.w600,
-                    color: Colors.black87,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 20),
-              // 내용
-              const StandardText(
-                text: '선택한 항목을 정말 삭제하시겠습니까?',
-                fontSize: 15,
-                color: Colors.black87,
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 24),
-              // 액션 버튼
-              Row(
-                children: [
-                  Expanded(
-                    child: TextButton(
-                      onPressed: () => Navigator.of(dialogContext).pop(),
-                      style: TextButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 8),
-                        backgroundColor: Colors.grey[100],
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                // 내용
+                const StandardText(
+                  text: '선택한 항목을 정말 삭제하시겠습니까?',
+                  fontSize: 15,
+                  color: Colors.black87,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 24),
+                // 액션 버튼
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextButton(
+                        onPressed: () => Navigator.of(dialogContext).pop(),
+                        style: TextButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 8),
+                          backgroundColor: Colors.grey[100],
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                        child: const StandardText(
+                          text: '취소',
+                          fontSize: 14,
+                          color: Colors.black87,
                         ),
                       ),
-                      child: const StandardText(
-                        text: '취소',
-                        fontSize: 14,
-                        color: Colors.black87,
-                      ),
                     ),
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: TextButton(
-                      onPressed: () {
-                        Navigator.of(dialogContext).pop();
-                        _deleteSelectedItems();
-                      },
-                      style: TextButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 8),
-                        backgroundColor: Colors.red,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: TextButton(
+                        onPressed: () {
+                          Navigator.of(dialogContext).pop();
+                          _deleteSelectedItems();
+                        },
+                        style: TextButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 8),
+                          backgroundColor: Colors.red,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                        child: const StandardText(
+                          text: '삭제',
+                          fontSize: 14,
+                          color: Colors.white,
                         ),
                       ),
-                      child: const StandardText(
-                        text: '삭제',
-                        fontSize: 14,
-                        color: Colors.white,
-                      ),
                     ),
-                  ),
-                ],
-              ),
-            ],
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildPhoneWidthDialog(Widget child) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: _dialogMaxWidth),
+        child: child,
       ),
     );
   }

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -897,133 +897,147 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
         TextEditingController(text: defaultFolderName);
     final themeProvider = Provider.of<ThemeHandler>(context, listen: false);
     final standardTextStyle = const StandardText(text: '').getTextStyle();
+    final openTime = DateTime.now();
 
     await showDialog(
       context: context,
-      builder: (context) {
-        return Dialog(
-          backgroundColor: Colors.white,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-          child: Container(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // 헤더
-                Row(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.all(8),
-                      decoration: BoxDecoration(
-                        color: themeProvider.primaryColor.withOpacity(0.1),
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Icon(
-                        Icons.edit,
-                        color: themeProvider.primaryColor,
-                        size: 20,
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    StandardText(
-                      text: dialogTitle,
-                      fontSize: 20,
-                      fontWeight: FontWeight.w600,
-                      color: Colors.black87,
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 24),
-                // 입력 필드
-                TextField(
-                  controller: folderNameController,
-                  autofocus: true,
-                  style: standardTextStyle.copyWith(
-                    color: Colors.black87,
-                    fontSize: 15,
-                  ),
-                  decoration: InputDecoration(
-                    hintText: '공책 이름을 입력하세요',
-                    hintStyle: standardTextStyle.copyWith(
-                      color: Colors.grey[400],
-                      fontSize: 14,
-                    ),
-                    fillColor: Colors.grey[50],
-                    filled: true,
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                      borderSide:
-                          BorderSide(color: Colors.grey[300]!, width: 1),
-                    ),
-                    enabledBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                      borderSide:
-                          BorderSide(color: Colors.grey[300]!, width: 1),
-                    ),
-                    focusedBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                      borderSide: BorderSide(
-                        color: themeProvider.primaryColor.withOpacity(0.5),
-                        width: 2,
-                      ),
-                    ),
-                    contentPadding: const EdgeInsets.symmetric(
-                      vertical: 16,
-                      horizontal: 16,
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 24),
-                // 액션 버튼
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    TextButton(
-                      onPressed: () {
-                        Navigator.pop(context);
-                      },
-                      style: TextButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 8),
-                        backgroundColor: Colors.grey[100],
-                        shape: RoundedRectangleBorder(
+      barrierDismissible: false,
+      builder: (dialogContext) {
+        return TapRegion(
+          onTapOutside: (_) {
+            // Workaround for iPadOS 26.1 bug: https://github.com/flutter/flutter/issues/177992
+            if (DateTime.now().difference(openTime) <
+                const Duration(milliseconds: 500)) {
+              return;
+            }
+            if (Navigator.canPop(dialogContext)) {
+              Navigator.pop(dialogContext);
+            }
+          },
+          child: Dialog(
+            backgroundColor: Colors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Container(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 헤더
+                  Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: themeProvider.primaryColor.withOpacity(0.1),
                           borderRadius: BorderRadius.circular(8),
                         ),
+                        child: Icon(
+                          Icons.edit,
+                          color: themeProvider.primaryColor,
+                          size: 20,
+                        ),
                       ),
-                      child: const StandardText(
-                        text: '취소',
-                        fontSize: 14,
+                      const SizedBox(width: 12),
+                      StandardText(
+                        text: dialogTitle,
+                        fontSize: 20,
+                        fontWeight: FontWeight.w600,
                         color: Colors.black87,
                       ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  // 입력 필드
+                  TextField(
+                    controller: folderNameController,
+                    autofocus: true,
+                    style: standardTextStyle.copyWith(
+                      color: Colors.black87,
+                      fontSize: 15,
                     ),
-                    const SizedBox(width: 8),
-                    TextButton(
-                      onPressed: () async {
-                        if (folderNameController.text.isNotEmpty) {
-                          onFolderNameSubmitted(folderNameController.text);
-                          Navigator.pop(context);
-                        }
-                      },
-                      style: TextButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 8),
-                        backgroundColor: themeProvider.primaryColor,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
+                    decoration: InputDecoration(
+                      hintText: '공책 이름을 입력하세요',
+                      hintStyle: standardTextStyle.copyWith(
+                        color: Colors.grey[400],
+                        fontSize: 14,
+                      ),
+                      fillColor: Colors.grey[50],
+                      filled: true,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide:
+                            BorderSide(color: Colors.grey[300]!, width: 1),
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide:
+                            BorderSide(color: Colors.grey[300]!, width: 1),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(
+                          color: themeProvider.primaryColor.withOpacity(0.5),
+                          width: 2,
                         ),
                       ),
-                      child: const StandardText(
-                        text: '확인',
-                        fontSize: 14,
-                        color: Colors.white,
+                      contentPadding: const EdgeInsets.symmetric(
+                        vertical: 16,
+                        horizontal: 16,
                       ),
                     ),
-                  ],
-                ),
-              ],
+                  ),
+                  const SizedBox(height: 24),
+                  // 액션 버튼
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton(
+                        onPressed: () {
+                          Navigator.pop(dialogContext);
+                        },
+                        style: TextButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 8),
+                          backgroundColor: Colors.grey[100],
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                        child: const StandardText(
+                          text: '취소',
+                          fontSize: 14,
+                          color: Colors.black87,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      TextButton(
+                        onPressed: () async {
+                          if (folderNameController.text.isNotEmpty) {
+                            onFolderNameSubmitted(folderNameController.text);
+                            Navigator.pop(dialogContext);
+                          }
+                        },
+                        style: TextButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 8),
+                          backgroundColor: themeProvider.primaryColor,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                        child: const StandardText(
+                          text: '확인',
+                          fontSize: 14,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ),
         );

--- a/lib/Screen/PracticeNote/PracticeProblemSelectionScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeProblemSelectionScreen.dart
@@ -267,6 +267,8 @@ class _PracticeProblemSelectionScreenState
 
   Widget _buildFolderList(BuildContext context, ThemeHandler themeProvider) {
     double screenWidth = MediaQuery.of(context).size.width;
+    final isWide = screenWidth >= 600;
+    final folderGap = isWide ? 18.0 : 12.0;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 10.0),
@@ -302,7 +304,7 @@ class _PracticeProblemSelectionScreenState
                 await _loadInitialProblems(folder.folderId);
               },
               child: Padding(
-                padding: EdgeInsets.only(right: screenWidth * 0.04),
+                padding: EdgeInsets.only(right: folderGap),
                 child: _buildFolderThumbnail(folder, themeProvider),
               ),
             );
@@ -315,6 +317,9 @@ class _PracticeProblemSelectionScreenState
   Widget _buildFolderThumbnail(
       FolderThumbnailModel folder, ThemeHandler themeProvider) {
     bool isSelected = selectedFolderId == folder.folderId; // 선택된 폴더인지 확인
+    final screenWidth = MediaQuery.of(context).size.width;
+    final isWide = screenWidth >= 600;
+    final folderNameWidth = isWide ? 120.0 : screenWidth * 0.2;
 
     return Opacity(
       opacity: isSelected ? 1.0 : 0.5, // 선택된 폴더가 아니라면 흐리게 표시
@@ -327,7 +332,7 @@ class _PracticeProblemSelectionScreenState
           ),
           const SizedBox(height: 8),
           SizedBox(
-            width: MediaQuery.of(context).size.width * 0.2,
+            width: folderNameWidth,
             child: StandardText(
               text: folder.folderName.length > 10
                   ? '${folder.folderName.substring(0, 10)}..'

--- a/lib/Screen/ProblemDetail/ProblemDetailScreen.dart
+++ b/lib/Screen/ProblemDetail/ProblemDetailScreen.dart
@@ -231,7 +231,7 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
               },
             ),
           ),
-          const SizedBox(height: 10),
+          const SizedBox(height: 2),
           _buildNavigationButtons(context, widget.isPractice),
         ],
       ),
@@ -630,7 +630,7 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
     double screenHeight = MediaQuery.of(context).size.height;
 
     // 화면 높이에 따라 패딩 값을 동적으로 설정
-    double topPadding = screenHeight * 0.01;
+    double topPadding = 0;
     double bottomPadding = screenHeight * 0.03;
 
     if (isPractice) {

--- a/lib/Screen/ProblemDetail/ProblemDetailScreenWidget.dart
+++ b/lib/Screen/ProblemDetail/ProblemDetailScreenWidget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:ono/Module/Text/HandWriteText.dart';
 
 import '../../Model/Problem/ProblemModel.dart';
 import '../../Module/Theme/GridPainter.dart';
@@ -65,7 +64,6 @@ class ProblemDetailScreenWidget {
                 '해설 이미지',
                 theme),
             verticalSpacer(ctx, .04),
-
             buildAnalysisSection(ctx, problem.analysis, theme.primaryColor),
             verticalSpacer(ctx, .04),
             buildRepeatSection(ctx, problem, theme.primaryColor),

--- a/lib/Screen/ProblemDetail/ProblemDetailTemplate.dart
+++ b/lib/Screen/ProblemDetail/ProblemDetailTemplate.dart
@@ -60,7 +60,7 @@ class _ProblemDetailTemplateState extends State<ProblemDetailTemplate>
     return Column(
       children: [
         // 노트 헤더 (손글씨 탭 바)
-        _buildNoteHeader(themeProvider),
+        _buildNoteHeader(themeProvider, isWide),
 
         // 탭 내용
         Expanded(
@@ -86,77 +86,126 @@ class _ProblemDetailTemplateState extends State<ProblemDetailTemplate>
     );
   }
 
-  Widget _buildNoteHeader(ThemeHandler themeProvider) {
+  Widget _buildNoteHeader(ThemeHandler themeProvider, bool isWide) {
+    final horizontalPadding = isWide ? 60.0 : 30.0;
+
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 5.0),
+      padding:
+          EdgeInsets.fromLTRB(horizontalPadding, 10.0, horizontalPadding, 8.0),
       decoration: BoxDecoration(
-        color: Colors.white.withOpacity(0.9),
+        color: Colors.white.withOpacity(0.94),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.05),
-            blurRadius: 4,
+            color: Colors.black.withOpacity(0.06),
+            blurRadius: 8,
             offset: const Offset(0, 2),
           ),
         ],
       ),
-      child: TabBar(
-        controller: _tabController,
-        labelColor: themeProvider.primaryColor,
-        unselectedLabelColor: Colors.grey[600],
-        indicator: BoxDecoration(
-          color: themeProvider.primaryColor.withOpacity(0.15),
-          borderRadius: BorderRadius.circular(20),
+      child: Container(
+        padding: const EdgeInsets.all(5),
+        decoration: BoxDecoration(
+          color: Colors.grey[100],
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: Colors.grey[200]!, width: 1),
         ),
-        indicatorSize: TabBarIndicatorSize.tab,
-        dividerColor: Colors.transparent,
-        labelPadding: const EdgeInsets.symmetric(horizontal: 8),
-        tabs: [
-          Tab(
-            child: StandardText(
-              text: '문제',
-              fontSize: 16,
-              fontWeight:
-                  _currentTabIndex == 0 ? FontWeight.bold : FontWeight.normal,
-              color: _currentTabIndex == 0
-                  ? themeProvider.primaryColor
-                  : Colors.grey[600]!,
+        child: TabBar(
+          controller: _tabController,
+          labelColor: themeProvider.primaryColor,
+          unselectedLabelColor: Colors.grey[600],
+          indicator: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: themeProvider.primaryColor.withOpacity(0.22),
+              width: 1,
             ),
+            boxShadow: [
+              BoxShadow(
+                color: themeProvider.primaryColor.withOpacity(0.1),
+                blurRadius: 6,
+                offset: const Offset(0, 2),
+              ),
+            ],
           ),
-          Tab(
-            child: StandardText(
-              text: '정답',
-              fontSize: 16,
-              fontWeight:
-                  _currentTabIndex == 1 ? FontWeight.bold : FontWeight.normal,
-              color: _currentTabIndex == 1
-                  ? themeProvider.primaryColor
-                  : Colors.grey[600]!,
+          indicatorSize: TabBarIndicatorSize.tab,
+          dividerColor: Colors.transparent,
+          labelPadding: const EdgeInsets.symmetric(horizontal: 4),
+          tabs: [
+            Tab(
+              child: _buildHeaderTab(
+                title: '문제',
+                icon: Icons.help_outline,
+                isActive: _currentTabIndex == 0,
+                isWide: isWide,
+                themeProvider: themeProvider,
+              ),
             ),
-          ),
-          Tab(
-            child: StandardText(
-              text: '복습 기록',
-              fontSize: 16,
-              fontWeight:
-                  _currentTabIndex == 2 ? FontWeight.bold : FontWeight.normal,
-              color: _currentTabIndex == 2
-                  ? themeProvider.primaryColor
-                  : Colors.grey[600]!,
+            Tab(
+              child: _buildHeaderTab(
+                title: '정답',
+                icon: Icons.task_alt,
+                isActive: _currentTabIndex == 1,
+                isWide: isWide,
+                themeProvider: themeProvider,
+              ),
             ),
-          ),
-        ],
+            Tab(
+              child: _buildHeaderTab(
+                title: '복습 기록',
+                icon: Icons.history_edu,
+                isActive: _currentTabIndex == 2,
+                isWide: isWide,
+                themeProvider: themeProvider,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
 
+  Widget _buildHeaderTab({
+    required String title,
+    required IconData icon,
+    required bool isActive,
+    required bool isWide,
+    required ThemeHandler themeProvider,
+  }) {
+    final activeColor = themeProvider.primaryColor;
+    final inactiveColor = Colors.grey[600]!;
+    final iconSize = isWide ? 16.0 : 14.0;
+    final textSize = isWide ? 16.0 : 14.0;
+    final gap = isWide ? 6.0 : 4.0;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(
+          icon,
+          size: iconSize,
+          color: isActive ? activeColor : inactiveColor,
+        ),
+        SizedBox(width: gap),
+        StandardText(
+          text: title,
+          fontSize: textSize,
+          fontWeight: isActive ? FontWeight.bold : FontWeight.w500,
+          color: isActive ? activeColor : inactiveColor,
+        ),
+      ],
+    );
+  }
+
   Widget _buildProblemTab(ThemeHandler themeProvider, bool isWide) {
+    final horizontalPadding = isWide ? 60.0 : 30.0;
     final problemImageCount =
         widget.problemModel.problemImageDataList?.length ?? 0;
 
     return SingleChildScrollView(
       physics: const AlwaysScrollableScrollPhysics(),
       padding: EdgeInsets.symmetric(
-        horizontal: isWide ? 60.0 : 35.0,
+        horizontal: horizontalPadding,
         vertical: 24.0,
       ),
       child: Column(
@@ -332,12 +381,13 @@ class _ProblemDetailTemplateState extends State<ProblemDetailTemplate>
   }
 
   Widget _buildSolutionTab(ThemeHandler themeProvider, bool isWide) {
+    final horizontalPadding = isWide ? 60.0 : 30.0;
     final answerImageCount =
         widget.problemModel.answerImageDataList?.length ?? 0;
 
     // 공통 패딩
     final contentPadding = EdgeInsets.symmetric(
-      horizontal: isWide ? 60.0 : 35.0,
+      horizontal: horizontalPadding,
       vertical: 24.0,
     );
 

--- a/lib/Screen/ProblemDetail/ProblemDetailTemplate.dart
+++ b/lib/Screen/ProblemDetail/ProblemDetailTemplate.dart
@@ -332,6 +332,9 @@ class _ProblemDetailTemplateState extends State<ProblemDetailTemplate>
   }
 
   Widget _buildSolutionTab(ThemeHandler themeProvider, bool isWide) {
+    final answerImageCount =
+        widget.problemModel.answerImageDataList?.length ?? 0;
+
     // 공통 패딩
     final contentPadding = EdgeInsets.symmetric(
       horizontal: isWide ? 60.0 : 35.0,
@@ -368,16 +371,24 @@ class _ProblemDetailTemplateState extends State<ProblemDetailTemplate>
         ],
 
         // 해설 이미지
-        _buildSectionTitle('해설 이미지', Icons.image_outlined, themeProvider),
-        const SizedBox(height: 12),
-        buildImageSection(
-          context,
-          widget.problemModel.answerImageDataList
-                  ?.map((m) => m.imageUrl)
-                  .toList() ??
-              [],
+        _buildSectionTitle(
           '해설 이미지',
+          Icons.image_outlined,
           themeProvider,
+          trailing: _buildCountChip(answerImageCount, themeProvider),
+        ),
+        const SizedBox(height: 12),
+        _buildProblemImagePanel(
+          themeProvider,
+          child: buildImageSection(
+            context,
+            widget.problemModel.answerImageDataList
+                    ?.map((m) => m.imageUrl)
+                    .toList() ??
+                [],
+            '해설 이미지',
+            themeProvider,
+          ),
         ),
       ],
     );

--- a/lib/Screen/ProblemDetail/ProblemDetailTemplate.dart
+++ b/lib/Screen/ProblemDetail/ProblemDetailTemplate.dart
@@ -150,6 +150,9 @@ class _ProblemDetailTemplateState extends State<ProblemDetailTemplate>
   }
 
   Widget _buildProblemTab(ThemeHandler themeProvider, bool isWide) {
+    final problemImageCount =
+        widget.problemModel.problemImageDataList?.length ?? 0;
+
     return SingleChildScrollView(
       physics: const AlwaysScrollableScrollPhysics(),
       padding: EdgeInsets.symmetric(
@@ -159,57 +162,172 @@ class _ProblemDetailTemplateState extends State<ProblemDetailTemplate>
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // 푼 날짜
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Row(
-                children: [
-                  Container(
-                    padding: const EdgeInsets.all(6.0),
-                    decoration: BoxDecoration(
-                      color: themeProvider.primaryColor.withOpacity(0.1),
-                      borderRadius: BorderRadius.circular(6.0),
-                    ),
-                    child: Icon(
-                      Icons.calendar_today_outlined,
-                      color: themeProvider.primaryColor,
-                      size: 18,
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  StandardText(
-                    text: '푼 날짜',
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                    color: Colors.black87,
-                  ),
-                ],
-              ),
-              UnderlinedText(
-                text: DateFormat('yyyy년 M월 d일')
-                    .format(widget.problemModel.solvedAt!),
-                fontSize: 15,
-              ),
-            ],
-          ),
+          _buildProblemMetaCard(themeProvider),
           const SizedBox(height: 30),
 
           // 문제 이미지
-          _buildSectionTitle('문제 이미지', Icons.image_outlined, themeProvider),
-          const SizedBox(height: 12),
-          buildImageSection(
-            context,
-            widget.problemModel.problemImageDataList
-                    ?.map((m) => m.imageUrl)
-                    .toList() ??
-                [],
+          _buildProblemSectionHeaderCard(
             '문제 이미지',
+            Icons.image_outlined,
             themeProvider,
+            trailing: _buildCountChip(problemImageCount, themeProvider),
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: 16),
+          _buildProblemImagePanel(
+            themeProvider,
+            child: buildImageSection(
+              context,
+              widget.problemModel.problemImageDataList
+                      ?.map((m) => m.imageUrl)
+                      .toList() ??
+                  [],
+              '문제 이미지',
+              themeProvider,
+            ),
+          ),
+          const SizedBox(height: 34),
         ],
       ),
+    );
+  }
+
+  Widget _buildProblemMetaCard(ThemeHandler themeProvider) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 14.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(14.0),
+        border: Border.all(
+          color: themeProvider.primaryColor.withOpacity(0.18),
+          width: 1.2,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(8.0),
+            decoration: BoxDecoration(
+              color: themeProvider.primaryColor.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(10.0),
+            ),
+            child: Icon(
+              Icons.calendar_today_outlined,
+              color: themeProvider.primaryColor,
+              size: 18,
+            ),
+          ),
+          const SizedBox(width: 10),
+          const StandardText(
+            text: '푼 날짜',
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            color: Colors.black87,
+          ),
+          const Spacer(),
+          UnderlinedText(
+            text:
+                DateFormat('yyyy년 M월 d일').format(widget.problemModel.solvedAt!),
+            fontSize: 15,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCountChip(int count, ThemeHandler themeProvider) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: themeProvider.primaryColor.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: StandardText(
+        text: '$count장',
+        fontSize: 12,
+        fontWeight: FontWeight.w600,
+        color: themeProvider.primaryColor,
+      ),
+    );
+  }
+
+  Widget _buildProblemSectionHeaderCard(
+      String title, IconData icon, ThemeHandler themeProvider,
+      {Widget? trailing}) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 14.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(14.0),
+        border: Border.all(
+          color: themeProvider.primaryColor.withOpacity(0.18),
+          width: 1.2,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(8.0),
+            decoration: BoxDecoration(
+              color: themeProvider.primaryColor.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(10.0),
+            ),
+            child: Icon(
+              icon,
+              color: themeProvider.primaryColor,
+              size: 18,
+            ),
+          ),
+          const SizedBox(width: 10),
+          StandardText(
+            text: title,
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            color: Colors.black87,
+          ),
+          const Spacer(),
+          if (trailing != null) trailing,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProblemImagePanel(ThemeHandler themeProvider,
+      {required Widget child}) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(14.0),
+        border: Border.all(
+          color: themeProvider.primaryColor.withOpacity(0.14),
+          width: 1.1,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.03),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: child,
     );
   }
 
@@ -305,27 +423,40 @@ class _ProblemDetailTemplateState extends State<ProblemDetailTemplate>
   }
 
   Widget _buildSectionTitle(
-      String title, IconData icon, ThemeHandler themeProvider) {
-    return Row(
+      String title, IconData icon, ThemeHandler themeProvider,
+      {Widget? trailing}) {
+    return Column(
       children: [
-        Container(
-          padding: const EdgeInsets.all(6.0),
-          decoration: BoxDecoration(
-            color: themeProvider.primaryColor.withOpacity(0.1),
-            borderRadius: BorderRadius.circular(6.0),
-          ),
-          child: Icon(
-            icon,
-            color: themeProvider.primaryColor,
-            size: 18,
-          ),
+        Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(6.0),
+              decoration: BoxDecoration(
+                color: themeProvider.primaryColor.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(6.0),
+              ),
+              child: Icon(
+                icon,
+                color: themeProvider.primaryColor,
+                size: 18,
+              ),
+            ),
+            const SizedBox(width: 8),
+            StandardText(
+              text: title,
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+              color: Colors.black87,
+            ),
+            const Spacer(),
+            if (trailing != null) trailing,
+          ],
         ),
-        const SizedBox(width: 8),
-        StandardText(
-          text: title,
-          fontSize: 16,
-          fontWeight: FontWeight.w500,
-          color: Colors.black87,
+        const SizedBox(height: 8),
+        Divider(
+          color: themeProvider.primaryColor.withOpacity(0.2),
+          thickness: 1,
+          height: 1,
         ),
       ],
     );

--- a/lib/Screen/ProblemDetail/ProblemDetailTemplate.dart
+++ b/lib/Screen/ProblemDetail/ProblemDetailTemplate.dart
@@ -214,49 +214,94 @@ class _ProblemDetailTemplateState extends State<ProblemDetailTemplate>
   }
 
   Widget _buildSolutionTab(ThemeHandler themeProvider, bool isWide) {
-    return SingleChildScrollView(
-      padding: EdgeInsets.symmetric(
-        horizontal: isWide ? 60.0 : 35.0,
-        vertical: 24.0,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // 메모
-          if (widget.problemModel.memo != null &&
-              widget.problemModel.memo!.isNotEmpty) ...[
-            _buildSectionTitle('메모', Icons.edit, themeProvider),
-            const SizedBox(height: 12),
-            UnderlinedText(
-              text: widget.problemModel.memo!,
-              fontSize: 18,
-            ),
-            const SizedBox(height: 25),
-          ],
-
-          // 해설 이미지
-          _buildSectionTitle('해설 이미지', Icons.image_outlined, themeProvider),
-          const SizedBox(height: 12),
-          buildImageSection(
-            context,
-            widget.problemModel.answerImageDataList
-                    ?.map((m) => m.imageUrl)
-                    .toList() ??
-                [],
-            '해설 이미지',
-            themeProvider,
-          ),
-          const SizedBox(height: 24),
-
-          // AI 분석 결과
-          _buildSectionTitle('AI 분석 결과', Icons.auto_awesome, themeProvider),
-          const SizedBox(height: 12),
-          buildAnalysisSection(context, widget.problemModel.analysis,
-              themeProvider.primaryColor),
-          const SizedBox(height: 24),
-        ],
-      ),
+    // 공통 패딩
+    final contentPadding = EdgeInsets.symmetric(
+      horizontal: isWide ? 60.0 : 35.0,
+      vertical: 24.0,
     );
+
+    // AI 분석 결과 위젯
+    final aiAnalysisWidget = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSectionTitle('AI 분석 결과', Icons.auto_awesome, themeProvider),
+        const SizedBox(height: 12),
+        buildAnalysisSection(
+            context, widget.problemModel.analysis, themeProvider.primaryColor),
+      ],
+    );
+
+    // 메모 및 해설 이미지 위젯
+    final memoAndImageWidget = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.problemModel.memo != null &&
+            widget.problemModel.memo!.isNotEmpty) ...[
+          _buildSectionTitle('메모', Icons.edit, themeProvider),
+          const SizedBox(height: 12),
+          UnderlinedText(
+            text: widget.problemModel.memo!,
+            fontSize: 18,
+          ),
+          const SizedBox(height: 25),
+        ],
+
+        // 해설 이미지
+        _buildSectionTitle('해설 이미지', Icons.image_outlined, themeProvider),
+        const SizedBox(height: 12),
+        buildImageSection(
+          context,
+          widget.problemModel.answerImageDataList
+                  ?.map((m) => m.imageUrl)
+                  .toList() ??
+              [],
+          '해설 이미지',
+          themeProvider,
+        ),
+      ],
+    );
+
+    if (isWide) {
+      // 태블릿 가로 (2열) 레이아웃
+      return SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: contentPadding,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              flex: 1,
+              child: Padding(
+                padding: const EdgeInsets.only(right: 20.0), // 오른쪽 여백
+                child: memoAndImageWidget,
+              ),
+            ),
+            Expanded(
+              flex: 1,
+              child: Padding(
+                padding: const EdgeInsets.only(left: 20.0), // 왼쪽 여백
+                child: aiAnalysisWidget,
+              ),
+            ),
+          ],
+        ),
+      );
+    } else {
+      // 휴대폰 또는 태블릿 세로 (1열) 레이아웃
+      return SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: contentPadding,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            memoAndImageWidget,
+            const SizedBox(height: 24), // 두 섹션 사이 간격
+            aiAnalysisWidget,
+            const SizedBox(height: 24), // 마지막 섹션 하단 간격
+          ],
+        ),
+      );
+    }
   }
 
   Widget _buildSectionTitle(

--- a/lib/Screen/ProblemDetail/ProblemDetailTemplate.dart
+++ b/lib/Screen/ProblemDetail/ProblemDetailTemplate.dart
@@ -235,7 +235,7 @@ class _ProblemDetailTemplateState extends State<ProblemDetailTemplate>
           UnderlinedText(
             text:
                 DateFormat('yyyy년 M월 d일').format(widget.problemModel.solvedAt!),
-            fontSize: 15,
+            fontSize: 16,
           ),
         ],
       ),
@@ -357,9 +357,12 @@ class _ProblemDetailTemplateState extends State<ProblemDetailTemplate>
             widget.problemModel.memo!.isNotEmpty) ...[
           _buildSectionTitle('메모', Icons.edit, themeProvider),
           const SizedBox(height: 12),
-          UnderlinedText(
-            text: widget.problemModel.memo!,
-            fontSize: 18,
+          Padding(
+            padding: const EdgeInsets.only(left: 14.0),
+            child: UnderlinedText(
+              text: widget.problemModel.memo!,
+              fontSize: 18,
+            ),
           ),
           const SizedBox(height: 25),
         ],
@@ -425,40 +428,49 @@ class _ProblemDetailTemplateState extends State<ProblemDetailTemplate>
   Widget _buildSectionTitle(
       String title, IconData icon, ThemeHandler themeProvider,
       {Widget? trailing}) {
-    return Column(
-      children: [
-        Row(
-          children: [
-            Container(
-              padding: const EdgeInsets.all(6.0),
-              decoration: BoxDecoration(
-                color: themeProvider.primaryColor.withOpacity(0.1),
-                borderRadius: BorderRadius.circular(6.0),
-              ),
-              child: Icon(
-                icon,
-                color: themeProvider.primaryColor,
-                size: 18,
-              ),
-            ),
-            const SizedBox(width: 8),
-            StandardText(
-              text: title,
-              fontSize: 16,
-              fontWeight: FontWeight.w500,
-              color: Colors.black87,
-            ),
-            const Spacer(),
-            if (trailing != null) trailing,
-          ],
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 14.0, vertical: 12.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12.0),
+        border: Border.all(
+          color: themeProvider.primaryColor.withOpacity(0.14),
+          width: 1,
         ),
-        const SizedBox(height: 8),
-        Divider(
-          color: themeProvider.primaryColor.withOpacity(0.2),
-          thickness: 1,
-          height: 1,
-        ),
-      ],
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.02),
+            blurRadius: 6,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(6.0),
+            decoration: BoxDecoration(
+              color: themeProvider.primaryColor.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(6.0),
+            ),
+            child: Icon(
+              icon,
+              color: themeProvider.primaryColor,
+              size: 18,
+            ),
+          ),
+          const SizedBox(width: 8),
+          StandardText(
+            text: title,
+            fontSize: 16,
+            fontWeight: FontWeight.w500,
+            color: Colors.black87,
+          ),
+          const Spacer(),
+          if (trailing != null) trailing,
+        ],
+      ),
     );
   }
 

--- a/lib/Screen/ProblemDetail/Widget/ImageGallerySection.dart
+++ b/lib/Screen/ProblemDetail/Widget/ImageGallerySection.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:ono/Module/Text/HandWriteText.dart';
-
 import '../../../Module/Image/DisplayImage.dart';
 import '../../../Module/Image/FullScreenImage.dart';
 import '../../../Module/Theme/ThemeHandler.dart';
@@ -82,6 +80,51 @@ class _ImageGallerySectionState extends State<ImageGallerySection> {
           ),
         ),
         const SizedBox(height: 8),
+        if (widget.imageUrls.length > 1) ...[
+          SizedBox(
+            height: screenWidth > 600 ? 74 : 64,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              itemCount: widget.imageUrls.length,
+              separatorBuilder: (_, __) => const SizedBox(width: 8),
+              itemBuilder: (context, i) {
+                final isSelected = _current == i;
+                return GestureDetector(
+                  onTap: () {
+                    _controller.animateToPage(
+                      i,
+                      duration: const Duration(milliseconds: 220),
+                      curve: Curves.easeOut,
+                    );
+                  },
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 180),
+                    width: screenWidth > 600 ? 88 : 76,
+                    padding: const EdgeInsets.all(2),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(
+                        color: isSelected
+                            ? widget.themeProvider.primaryColor
+                            : widget.themeProvider.primaryColor
+                                .withOpacity(0.2),
+                        width: isSelected ? 2 : 1,
+                      ),
+                    ),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: DisplayImage(
+                        imagePath: widget.imageUrls[i],
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
         // 도트 인디케이터
         Row(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/Screen/ProblemDetail/Widget/RepeatSectionV2.dart
+++ b/lib/Screen/ProblemDetail/Widget/RepeatSectionV2.dart
@@ -664,10 +664,11 @@ class _ProblemSolveCard extends StatelessWidget {
     );
   }
 
-  void _showOptionsDialog(BuildContext context, ThemeHandler themeProvider) {
+  void _showOptionsDialog(
+      BuildContext parentContext, ThemeHandler themeProvider) {
     showDialog(
-      context: context,
-      builder: (context) => Dialog(
+      context: parentContext,
+      builder: (dialogContext) => Dialog(
         backgroundColor: Colors.white,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16),
@@ -741,8 +742,8 @@ class _ProblemSolveCard extends StatelessWidget {
                 width: double.infinity,
                 child: TextButton(
                   onPressed: () {
-                    Navigator.pop(context);
-                    _showDeleteConfirmDialog(context, themeProvider);
+                    Navigator.pop(dialogContext);
+                    _showDeleteConfirmDialog(parentContext, themeProvider);
                   },
                   style: TextButton.styleFrom(
                     padding: const EdgeInsets.symmetric(
@@ -772,7 +773,7 @@ class _ProblemSolveCard extends StatelessWidget {
               SizedBox(
                 width: double.infinity,
                 child: TextButton(
-                  onPressed: () => Navigator.pop(context),
+                  onPressed: () => Navigator.pop(dialogContext),
                   style: TextButton.styleFrom(
                     padding: const EdgeInsets.symmetric(
                         horizontal: 16, vertical: 12),
@@ -796,10 +797,10 @@ class _ProblemSolveCard extends StatelessWidget {
   }
 
   void _showDeleteConfirmDialog(
-      BuildContext context, ThemeHandler themeProvider) {
+      BuildContext parentContext, ThemeHandler themeProvider) {
     showDialog(
-      context: context,
-      builder: (context) => Dialog(
+      context: parentContext,
+      builder: (dialogContext) => Dialog(
         backgroundColor: Colors.white,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16),
@@ -847,7 +848,7 @@ class _ProblemSolveCard extends StatelessWidget {
                 children: [
                   Expanded(
                     child: TextButton(
-                      onPressed: () => Navigator.pop(context),
+                      onPressed: () => Navigator.pop(dialogContext),
                       style: TextButton.styleFrom(
                         padding: const EdgeInsets.symmetric(
                             horizontal: 12, vertical: 12),
@@ -867,8 +868,8 @@ class _ProblemSolveCard extends StatelessWidget {
                   Expanded(
                     child: TextButton(
                       onPressed: () {
-                        Navigator.pop(context);
-                        _handleDelete(context, themeProvider);
+                        Navigator.pop(dialogContext);
+                        _handleDelete(parentContext, themeProvider);
                       },
                       style: TextButton.styleFrom(
                         padding: const EdgeInsets.symmetric(
@@ -906,6 +907,7 @@ class _ProblemSolveCard extends StatelessWidget {
   // 삭제 핸들러
   Future<void> _handleDelete(
       BuildContext context, ThemeHandler themeProvider) async {
+    final rootNavigator = Navigator.of(context, rootNavigator: true);
     LoadingDialog.show(context, '복습 기록 삭제 중...');
 
     try {
@@ -914,12 +916,14 @@ class _ProblemSolveCard extends StatelessWidget {
 
       await problemSolveService.deleteProblemSolve(solveId);
 
+      // 먼저 새로고침 후 로딩 닫기
+      await onRefreshAsync();
+
+      if (rootNavigator.canPop()) {
+        rootNavigator.pop();
+      }
+
       if (context.mounted) {
-        // 먼저 새로고침
-        onRefreshAsync();
-
-        LoadingDialog.hide(context);
-
         SnackBarDialog.showSnackBar(
           context: context,
           message: '복습 기록이 삭제되었습니다.',
@@ -927,8 +931,10 @@ class _ProblemSolveCard extends StatelessWidget {
         );
       }
     } catch (e) {
+      if (rootNavigator.canPop()) {
+        rootNavigator.pop();
+      }
       if (context.mounted) {
-        LoadingDialog.hide(context);
         SnackBarDialog.showSnackBar(
           context: context,
           message: '복습 기록 삭제에 실패했습니다: $e',

--- a/lib/Screen/ProblemDetail/Widget/RepeatSectionV2.dart
+++ b/lib/Screen/ProblemDetail/Widget/RepeatSectionV2.dart
@@ -152,7 +152,7 @@ class _RepeatSectionV2State extends State<RepeatSectionV2>
 
         return ListView.builder(
           padding: const EdgeInsets.symmetric(
-            horizontal: 20.0,
+            horizontal: 30.0,
             vertical: 20.0,
           ),
           itemCount: latestFirst.length,
@@ -279,8 +279,8 @@ class _RepeatSectionV2WrapperState extends State<RepeatSectionV2Wrapper> {
         Container(
           width: double.infinity,
           padding: EdgeInsets.only(
-            left: widget.isWide ? 60 : 25,
-            right: widget.isWide ? 60 : 25,
+            left: widget.isWide ? 60 : 30,
+            right: widget.isWide ? 60 : 30,
             top: 10,
             bottom: 10,
           ),

--- a/lib/Screen/ProblemDetail/Widget/RepeatSectionV2.dart
+++ b/lib/Screen/ProblemDetail/Widget/RepeatSectionV2.dart
@@ -282,17 +282,10 @@ class _RepeatSectionV2WrapperState extends State<RepeatSectionV2Wrapper> {
             left: widget.isWide ? 60 : 30,
             right: widget.isWide ? 60 : 30,
             top: 10,
-            bottom: 10,
+            bottom: 16,
           ),
           decoration: BoxDecoration(
             color: Colors.white,
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withOpacity(0.1),
-                blurRadius: 8,
-                offset: const Offset(0, -2),
-              ),
-            ],
           ),
           child: SizedBox(
             height: 48,
@@ -321,7 +314,7 @@ class _RepeatSectionV2WrapperState extends State<RepeatSectionV2Wrapper> {
                 fontSize: 15,
                 fontWeight: FontWeight.bold,
               ),
-              elevation: 4,
+              elevation: 0,
             ),
           ),
         ),

--- a/lib/Screen/ProblemDetail/Widget/RepeatSectionV2.dart
+++ b/lib/Screen/ProblemDetail/Widget/RepeatSectionV2.dart
@@ -1095,10 +1095,10 @@ class _ImageSliderState extends State<_ImageSlider> {
         Container(
           height: screenHeight * 0.3,
           decoration: BoxDecoration(
-            color: widget.statusColor.withOpacity(0.05),
+            color: widget.primaryColor.withOpacity(0.05),
             borderRadius: BorderRadius.circular(12.0),
             border: Border.all(
-              color: widget.statusColor.withOpacity(0.2),
+              color: widget.primaryColor.withOpacity(0.2),
               width: 2,
             ),
           ),

--- a/lib/Screen/ProblemDetail/Widget/RepeatSectionV2.dart
+++ b/lib/Screen/ProblemDetail/Widget/RepeatSectionV2.dart
@@ -630,6 +630,21 @@ class _ProblemSolveCard extends StatelessWidget {
                   fontWeight: FontWeight.w500,
                   color: Colors.black87,
                 ),
+                const Spacer(),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: themeProvider.primaryColor.withOpacity(0.1),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: StandardText(
+                    text: '${solve.imageUrls.length}장',
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: themeProvider.primaryColor,
+                  ),
+                ),
               ],
             ),
             const SizedBox(height: 12),

--- a/lib/Screen/ProblemRegister/Widget/DatePickerHandler.dart
+++ b/lib/Screen/ProblemRegister/Widget/DatePickerHandler.dart
@@ -24,6 +24,17 @@ class _DatePickerHandlerState extends State<DatePickerHandler> {
   final List<int> _days =
       List<int>.generate(31, (int index) => index + 1); // 1부터 31까지
 
+  int _daysInMonth(int year, int month) {
+    return DateTime(year, month + 1, 0).day;
+  }
+
+  int _clampDay(int year, int month, int day) {
+    final maxDay = _daysInMonth(year, month);
+    if (day < 1) return 1;
+    if (day > maxDay) return maxDay;
+    return day;
+  }
+
   @override
   void initState() {
     super.initState();
@@ -32,142 +43,189 @@ class _DatePickerHandlerState extends State<DatePickerHandler> {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 0.0), // 좌우 여백 추가
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(20.0), // 모서리를 둥글게 처리
-        child: Container(
-          color: Colors.white,
-          height: MediaQuery.of(context).size.height / 3,
-          child: Column(
-            children: <Widget>[
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+    final primaryColor = Theme.of(context).primaryColor;
+
+    return ClipRRect(
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(24.0)),
+      child: Container(
+        color: Colors.white,
+        height: 360,
+        child: Column(
+          children: <Widget>[
+            const SizedBox(height: 10),
+            Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Colors.grey[300],
+                borderRadius: BorderRadius.circular(999),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Row(
                 children: [
-                  const SizedBox(width: 10), // 왼쪽 여백
-                  const Spacer(), // 가운데 비우기
                   TextButton(
-                    onPressed: () {
-                      // 완료 버튼을 누르면 선택한 날짜만 전달하고 모달 닫기
-                      if (Navigator.of(context).canPop()) {
-                        Navigator.pop(context, _selectedDate);
-                      }
-                    },
+                    onPressed: () => Navigator.pop(context),
                     child: const StandardText(
-                      text: '완료',
-                      fontSize: 16,
-                      color: Colors.black,
+                      text: '취소',
+                      fontSize: 15,
+                      color: Colors.black54,
                     ),
                   ),
-                  const SizedBox(width: 10), // 오른쪽 여백
+                  const Spacer(),
+                  const StandardText(
+                    text: '푼 날짜 선택',
+                    fontSize: 17,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.black87,
+                  ),
+                  const Spacer(),
+                  TextButton(
+                    onPressed: () => Navigator.pop(context, _selectedDate),
+                    child: StandardText(
+                      text: '완료',
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: primaryColor,
+                    ),
+                  ),
                 ],
               ),
-              const SizedBox(height: 20),
-              // 상단 마킹
-              const Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Divider(color: Colors.grey[200], height: 1),
+            ),
+            const SizedBox(height: 12),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16.0),
+              child: Row(
                 children: [
                   Expanded(
-                    child: Align(
-                      alignment: Alignment.center,
+                    child: Center(
                       child: StandardText(
                         text: '년도',
-                        fontSize: 16,
-                        color: Colors.black,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                        color: Colors.black54,
                       ),
                     ),
                   ),
                   Expanded(
-                    child: Align(
-                      alignment: Alignment.center,
+                    child: Center(
                       child: StandardText(
                         text: '월',
-                        fontSize: 16,
-                        color: Colors.black,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                        color: Colors.black54,
                       ),
                     ),
                   ),
                   Expanded(
-                    child: Align(
-                      alignment: Alignment.center,
+                    child: Center(
                       child: StandardText(
                         text: '일',
-                        fontSize: 16,
-                        color: Colors.black,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                        color: Colors.black54,
                       ),
                     ),
                   ),
                 ],
               ),
-              const SizedBox(height: 8), // 텍스트 아래에 약간의 여백 추가
-              // 날짜 선택기
-              Expanded(
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
                 child: Row(
                   children: <Widget>[
-                    Expanded(
+                    _buildPickerColumn(
                       child: CupertinoPicker(
                         scrollController: FixedExtentScrollController(
                           initialItem: _selectedDate.year - 2020,
                         ),
-                        itemExtent: 32.0,
+                        itemExtent: 34.0,
+                        useMagnifier: true,
+                        magnification: 1.06,
                         onSelectedItemChanged: (int index) {
                           setState(() {
-                            _selectedDate = DateTime(
-                              _years[index],
+                            final year = _years[index];
+                            final day = _clampDay(
+                              year,
                               _selectedDate.month,
                               _selectedDate.day,
                             );
+                            _selectedDate =
+                                DateTime(year, _selectedDate.month, day);
                           });
                         },
                         children: _years.map((int year) {
                           return Center(
                             child: StandardText(
                               text: '$year',
-                              fontSize: 16,
-                              color: Colors.black,
+                              fontSize: 17,
+                              color: Colors.black87,
                             ),
                           );
                         }).toList(),
                       ),
                     ),
-                    Expanded(
+                    const SizedBox(width: 10),
+                    _buildPickerColumn(
                       child: CupertinoPicker(
                         scrollController: FixedExtentScrollController(
                           initialItem: _selectedDate.month - 1,
                         ),
-                        itemExtent: 32.0,
+                        itemExtent: 34.0,
+                        useMagnifier: true,
+                        magnification: 1.06,
                         onSelectedItemChanged: (int index) {
                           setState(() {
-                            _selectedDate = DateTime(
+                            final month = _months[index];
+                            final day = _clampDay(
                               _selectedDate.year,
-                              _months[index],
+                              month,
                               _selectedDate.day,
                             );
+                            _selectedDate =
+                                DateTime(_selectedDate.year, month, day);
                           });
                         },
                         children: _months.map((int month) {
                           return Center(
                             child: StandardText(
                               text: '$month',
-                              fontSize: 16,
-                              color: Colors.black,
+                              fontSize: 17,
+                              color: Colors.black87,
                             ),
                           );
                         }).toList(),
                       ),
                     ),
-                    Expanded(
+                    const SizedBox(width: 10),
+                    _buildPickerColumn(
                       child: CupertinoPicker(
                         scrollController: FixedExtentScrollController(
                           initialItem: _selectedDate.day - 1,
                         ),
-                        itemExtent: 32.0,
+                        itemExtent: 34.0,
+                        useMagnifier: true,
+                        magnification: 1.06,
                         onSelectedItemChanged: (int index) {
                           setState(() {
+                            final requestedDay = _days[index];
+                            final day = _clampDay(
+                              _selectedDate.year,
+                              _selectedDate.month,
+                              requestedDay,
+                            );
                             _selectedDate = DateTime(
                               _selectedDate.year,
                               _selectedDate.month,
-                              _days[index],
+                              day,
                             );
                           });
                         },
@@ -175,8 +233,8 @@ class _DatePickerHandlerState extends State<DatePickerHandler> {
                           return Center(
                             child: StandardText(
                               text: '$day',
-                              fontSize: 16,
-                              color: Colors.black,
+                              fontSize: 17,
+                              color: Colors.black87,
                             ),
                           );
                         }).toList(),
@@ -185,9 +243,23 @@ class _DatePickerHandlerState extends State<DatePickerHandler> {
                   ],
                 ),
               ),
-            ],
-          ),
+            ),
+            const SizedBox(height: 10),
+          ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildPickerColumn({required Widget child}) {
+    return Expanded(
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.grey[50],
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: Colors.grey[200]!, width: 1),
+        ),
+        child: child,
       ),
     );
   }

--- a/lib/Screen/ProblemRegister/Widget/DatePickerWidget.dart
+++ b/lib/Screen/ProblemRegister/Widget/DatePickerWidget.dart
@@ -18,6 +18,8 @@ class DatePickerWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Provider.of<ThemeHandler>(context);
+    final screenWidth = MediaQuery.of(context).size.width;
+    final selectorWidth = screenWidth >= 600 ? 210.0 : 170.0;
 
     return Container(
       padding: const EdgeInsets.all(16.0),
@@ -49,42 +51,53 @@ class DatePickerWidget extends StatelessWidget {
               color: Colors.black87,
             ),
           ),
-          GestureDetector(
-            onTap: () async {
-              FirebaseAnalytics.instance.logEvent(name: 'date_select');
-              final d = await showModalBottomSheet<DateTime>(
-                context: context,
-                builder: (_) => DatePickerHandler(
-                  initialDate: selectedDate,
-                  onDateSelected: (d) => Navigator.pop(context, d),
+          SizedBox(
+            width: selectorWidth,
+            child: GestureDetector(
+              onTap: () async {
+                FirebaseAnalytics.instance.logEvent(name: 'date_select');
+                final d = await showModalBottomSheet<DateTime>(
+                  context: context,
+                  builder: (_) => DatePickerHandler(
+                    initialDate: selectedDate,
+                    onDateSelected: (d) => Navigator.pop(context, d),
+                  ),
+                );
+                if (d != null) onDateChanged(d);
+              },
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.grey[300]!, width: 1),
                 ),
-              );
-              if (d != null) onDateChanged(d);
-            },
-            child: Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey[300]!, width: 1),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  StandardText(
-                    text:
-                        '${selectedDate.year}년 ${selectedDate.month}월 ${selectedDate.day}일',
-                    fontSize: 14,
-                    color: Colors.black87,
-                  ),
-                  const SizedBox(width: 4),
-                  Icon(
-                    Icons.arrow_drop_down,
-                    color: Colors.grey[600],
-                    size: 20,
-                  ),
-                ],
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: FittedBox(
+                          fit: BoxFit.scaleDown,
+                          alignment: Alignment.centerRight,
+                          child: StandardText(
+                            text:
+                                '${selectedDate.year}년 ${selectedDate.month}월 ${selectedDate.day}일',
+                            fontSize: 14,
+                            color: Colors.black87,
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    Icon(
+                      Icons.arrow_drop_down,
+                      color: Colors.grey[600],
+                      size: 20,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/Screen/ProblemRegister/Widget/LabeledTextField.dart
+++ b/lib/Screen/ProblemRegister/Widget/LabeledTextField.dart
@@ -28,65 +28,78 @@ class LabeledTextField extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          children: [
-            Container(
-              padding: const EdgeInsets.all(6.0),
-              decoration: BoxDecoration(
-                color: themeProvider.primaryColor.withOpacity(0.1),
-                borderRadius: BorderRadius.circular(6.0),
-              ),
-              child: Icon(
-                icon ?? Icons.label,
-                color: themeProvider.primaryColor,
-                size: 18,
-              ),
-            ),
-            const SizedBox(width: 8),
-            StandardText(
-              text: label,
-              fontSize: 16,
-              fontWeight: FontWeight.w500,
-              color: Colors.black87,
-            ),
-          ],
-        ),
-        const SizedBox(height: 12),
-        TextField(
-          controller: controller,
-          style: standardTextStyle.copyWith(
-            color: Colors.black87,
-            fontSize: 15,
+        Container(
+          padding: const EdgeInsets.all(16.0),
+          decoration: BoxDecoration(
+            color: Colors.grey[50],
+            borderRadius: BorderRadius.circular(12.0),
+            border: Border.all(color: Colors.grey[200]!, width: 1),
           ),
-          decoration: InputDecoration(
-            border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: Colors.grey[300]!, width: 1),
-            ),
-            enabledBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: Colors.grey[300]!, width: 1),
-            ),
-            focusedBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(
-                color: themeProvider.primaryColor.withOpacity(0.5),
-                width: 2,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(8.0),
+                    decoration: BoxDecoration(
+                      color: themeProvider.primaryColor.withOpacity(0.1),
+                      borderRadius: BorderRadius.circular(8.0),
+                    ),
+                    child: Icon(
+                      icon ?? Icons.label,
+                      color: themeProvider.primaryColor,
+                      size: 20,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  StandardText(
+                    text: label,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                    color: Colors.black87,
+                  ),
+                ],
               ),
-            ),
-            fillColor: Colors.grey[50],
-            filled: true,
-            hintText: hintText,
-            hintStyle: standardTextStyle.copyWith(
-              color: Colors.grey[400],
-              fontSize: 14,
-            ),
-            contentPadding: EdgeInsets.symmetric(
-              horizontal: 16,
-              vertical: maxLines > 1 ? 16 : 14,
-            ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: controller,
+                style: standardTextStyle.copyWith(
+                  color: Colors.black87,
+                  fontSize: 15,
+                ),
+                decoration: InputDecoration(
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(color: Colors.grey[300]!, width: 1),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(color: Colors.grey[300]!, width: 1),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(
+                      color: themeProvider.primaryColor.withOpacity(0.5),
+                      width: 2,
+                    ),
+                  ),
+                  fillColor: Colors.white,
+                  filled: true,
+                  hintText: hintText,
+                  hintStyle: standardTextStyle.copyWith(
+                    color: Colors.grey[400],
+                    fontSize: 14,
+                  ),
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: maxLines > 1 ? 16 : 14,
+                  ),
+                ),
+                maxLines: maxLines,
+              ),
+            ],
           ),
-          maxLines: maxLines,
         ),
       ],
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -170,6 +170,9 @@ class MyApp extends StatelessWidget {
       colorScheme: ColorScheme.fromSeed(seedColor: themeHandler.primaryColor),
       primaryColor: themeHandler.primaryColor,
       useMaterial3: true,
+      dialogTheme: const DialogThemeData(
+        constraints: BoxConstraints(maxWidth: 420),
+      ),
     );
   }
 }


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #123 

## 📝 작업 내용

> 오답노트 복습 기능 추가로 인한 오답노트 상세 페이지 디자인 개선에 따라, 태블릿 화면 디자인을 개선했습니다

- 문제 섹션 디자인 개선
  - 이미지 개수 출력
  - 여러 개의 이미자가 포함될 경우, 하단의 이미지 썸네일 카드 추가

- 정답 섹션 디자인 개선
  - 왼쪽 영역은 메모, 해설 이미지 출력
  - 오른쪽 영역은 AI 분석 결과 출력

- 복습 기록 섹션 디자인 개선
  - 왼쪽 영역은 복습 기록 썸네일 출력
  - 오른쪽 영역은 복습 기록 상세 정보 출력

- 기타 디자인 개선
  - 오답노트 상세 페이지 상단 탭바 디자인 개선
  - 날짜 선택기 디자인 개선

### 스크린샷 (선택)

<img width="900" alt="image" src="https://github.com/user-attachments/assets/c454d94a-22dd-48bc-9852-fe2939fc784f" />
<img width="900" alt="image" src="https://github.com/user-attachments/assets/faeb1e12-db48-47f8-b453-a8e3b68df63d" />
<img width="900" alt="image" src="https://github.com/user-attachments/assets/ad6e8d66-5870-40bc-8ccc-4a76df4a57ad" />
<img width="900" alt="image" src="https://github.com/user-attachments/assets/6b869210-2952-4dc6-9007-56ad45b86d31" />

