### PR TITLE
[Fix] 3.6.1 안정성 개선

### DIFF
--- a/lib/Provider/StudyRoomProvider.dart
+++ b/lib/Provider/StudyRoomProvider.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 
 import '../Model/StudyRoom/ActivityFeedModel.dart';
@@ -226,6 +227,7 @@ class StudyRoomProvider extends ChangeNotifier {
       feedId: feedId,
       emoji: emojiKey,
     );
+    FirebaseAnalytics.instance.logEvent(name: 'feed_reaction_toggled');
     notifyListeners();
   }
 
@@ -258,6 +260,7 @@ class StudyRoomProvider extends ChangeNotifier {
       endAt: endAt,
     );
     challenges = [...challenges, newChallenge];
+    FirebaseAnalytics.instance.logEvent(name: 'challenge_created');
     notifyListeners();
   }
 
@@ -345,6 +348,7 @@ class StudyRoomProvider extends ChangeNotifier {
       sharedProblemId: sharedProblemId,
       emoji: emojiKey,
     );
+    FirebaseAnalytics.instance.logEvent(name: 'problem_reaction_toggled');
     notifyListeners();
   }
 
@@ -457,6 +461,7 @@ class StudyRoomProvider extends ChangeNotifier {
       commentId: commentId,
       emoji: emojiKey,
     );
+    FirebaseAnalytics.instance.logEvent(name: 'comment_reaction_toggled');
     notifyListeners();
   }
 

--- a/lib/Provider/TokenProvider.dart
+++ b/lib/Provider/TokenProvider.dart
@@ -31,10 +31,14 @@ class TokenProvider {
     try {
       return await storage.read(key: key);
     } on PlatformException catch (e) {
-      final msg = (e.message ?? '').toLowerCase();
-      // BAD_DECRYPT: Android에서 암호화 키 손상 시 발생하는 복구 불가 오류만 처리한다.
-      // 그 외 PlatformException(백그라운드 잠금, 생체인증 취소 등)은 재던진다.
-      if (!msg.contains('bad_decrypt') && !msg.contains('bad decrypt')) {
+      // FlutterSecureStorage Android: code="Exception encountered", message="read",
+      // details="javax.crypto.BadPaddingException: ...BAD_DECRYPT..."
+      // BAD_DECRYPT 정보는 e.message가 아닌 e.details에 들어오므로 셋 다 확인한다.
+      final combined =
+          '${e.code} ${e.message ?? ''} ${e.details ?? ''}'.toLowerCase();
+      if (!combined.contains('bad_decrypt') &&
+          !combined.contains('bad decrypt') &&
+          !combined.contains('badpaddingexception')) {
         rethrow;
       }
       debugPrint('SecureStorage key corruption detected (key=$key): $e');

--- a/lib/Provider/TokenProvider.dart
+++ b/lib/Provider/TokenProvider.dart
@@ -31,8 +31,15 @@ class TokenProvider {
     try {
       return await storage.read(key: key);
     } on PlatformException catch (e) {
-      debugPrint('SecureStorage read failed (key=$key): $e');
-      await storage.deleteAll();
+      final msg = (e.message ?? '').toLowerCase();
+      // BAD_DECRYPT: Android에서 암호화 키 손상 시 발생하는 복구 불가 오류만 처리한다.
+      // 그 외 PlatformException(백그라운드 잠금, 생체인증 취소 등)은 재던진다.
+      if (!msg.contains('bad_decrypt') && !msg.contains('bad decrypt')) {
+        rethrow;
+      }
+      debugPrint('SecureStorage key corruption detected (key=$key): $e');
+      await storage.delete(key: 'accessToken');
+      await storage.delete(key: 'refreshToken');
       await _notifyAuthFailure();
       throw UnauthorizedException(message: '보안 저장소가 손상되어 로그아웃되었습니다. 다시 로그인해주세요.');
     }

--- a/lib/Provider/TokenProvider.dart
+++ b/lib/Provider/TokenProvider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 
@@ -26,12 +27,23 @@ class TokenProvider {
     await _notifyAuthFailure();
   }
 
+  Future<String?> _safeRead(String key) async {
+    try {
+      return await storage.read(key: key);
+    } on PlatformException catch (e) {
+      debugPrint('SecureStorage read failed (key=$key): $e');
+      await storage.deleteAll();
+      await _notifyAuthFailure();
+      throw UnauthorizedException(message: '보안 저장소가 손상되어 로그아웃되었습니다. 다시 로그인해주세요.');
+    }
+  }
+
   Future<void> setAccessToken(String accessToken) async {
     await storage.write(key: 'accessToken', value: accessToken);
   }
 
   Future<String?> getAccessToken() async {
-    String? accessToken = await storage.read(key: 'accessToken');
+    String? accessToken = await _safeRead('accessToken');
 
     // access token이 충분히 유효하면 그대로 사용
     if (accessToken != null &&
@@ -44,7 +56,7 @@ class TokenProvider {
     if (accessToken != null) {
       try {
         await refreshAccessToken();
-        return await storage.read(key: 'accessToken') ?? accessToken;
+        return await _safeRead('accessToken') ?? accessToken;
       } catch (e) {
         if (e is UnauthorizedException) {
           rethrow;
@@ -57,7 +69,7 @@ class TokenProvider {
     debugPrint('Access token is missing. Try refresh.');
     await refreshAccessToken();
 
-    return await storage.read(key: 'accessToken');
+    return await _safeRead('accessToken');
   }
 
   Future<void> setRefreshToken(String refreshToken) async {
@@ -65,13 +77,13 @@ class TokenProvider {
   }
 
   Future<String?> getRefreshToken() async {
-    return await storage.read(key: 'refreshToken');
+    return await _safeRead('refreshToken');
   }
 
   Future<void> refreshAccessTokenIfNeeded({
     Duration threshold = const Duration(minutes: 5),
   }) async {
-    final accessToken = await storage.read(key: 'accessToken');
+    final accessToken = await _safeRead('accessToken');
     if (accessToken != null && !_isTokenExpiringSoon(accessToken, threshold)) {
       return;
     }
@@ -94,7 +106,7 @@ class TokenProvider {
   }
 
   Future<void> _refreshAccessTokenInternal() async {
-    String? refreshToken = await storage.read(key: 'refreshToken');
+    String? refreshToken = await _safeRead('refreshToken');
     if (refreshToken == null) {
       debugPrint('No refresh token available.');
       await _notifyAuthFailure();

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -767,6 +767,7 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
             Provider.of<FoldersProvider>(context, listen: false);
         await foldersProvider.createFolder(folderName,
             parentFolderId: _currentFolder?.folderId);
+        FirebaseAnalytics.instance.logEvent(name: 'folder_created');
 
         // 현재 화면 새로고침
         await _loadFolderData();
@@ -1783,6 +1784,13 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
 
       // 삭제 성공 메시지
       if (mounted) {
+        FirebaseAnalytics.instance.logEvent(
+          name: 'items_deleted',
+          parameters: {
+            'folder_count': _selectedFolderIds.length,
+            'problem_count': _selectedProblemIds.length,
+          },
+        );
         SnackBarDialog.showSnackBar(
           context: context,
           message: '선택된 항목이 삭제되었습니다!',

--- a/lib/Screen/PracticeNote/PracticeCompletionScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeCompletionScreen.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
@@ -247,6 +248,7 @@ class _PracticeCompletionScreenState extends State<PracticeCompletionScreen> {
               return;
             }
             if (!mounted) return;
+            FirebaseAnalytics.instance.logEvent(name: 'practice_session_completed');
             // 2번 pop: PracticeCompletionScreen -> PracticeDetailScreen -> PracticeThumbnailScreen
             // 두 번째 pop에서 true를 반환하여 썸네일 업데이트 신호 전달
             if (navigator.canPop()) {

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -112,6 +113,7 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
 
           await problemPracticeProvider
               .updatePractice(widget.practiceNoteUpdateModel!);
+          FirebaseAnalytics.instance.logEvent(name: 'practice_set_updated');
 
           if (!context.mounted) return;
           _showSnackBar(context, themeProvider, '복습 세트가 수정되었습니다.',
@@ -140,6 +142,7 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
           }
           await problemPracticeProvider
               .registerPractice(widget.practiceRegisterModel!);
+          FirebaseAnalytics.instance.logEvent(name: 'practice_set_created');
 
           if (!context.mounted) return;
           _showSnackBar(context, themeProvider, '복습 세트가 생성되었습니다.',

--- a/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
+++ b/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:camera/camera.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -911,6 +912,9 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
 
     if (!mounted) return;
 
+    FirebaseAnalytics.instance.logEvent(
+      name: widget.isEditMode ? 'problem_updated' : 'problem_created',
+    );
     showSuccessDialog(context);
 
     if (shouldPop) {

--- a/lib/Screen/ProblemRegister/TagSelectionScreen.dart
+++ b/lib/Screen/ProblemRegister/TagSelectionScreen.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -75,6 +76,7 @@ class _TagSelectionScreenState extends State<TagSelectionScreen> {
   Future<void> _createTag() async {
     final name = _tagNameCtrl.text.trim();
     if (name.isEmpty) return;
+    if (name.length > 30) return;
 
     setState(() => _isCreating = true);
     try {
@@ -86,6 +88,7 @@ class _TagSelectionScreenState extends State<TagSelectionScreen> {
         _tags[index] = created;
       }
       _tags.sort((a, b) => a.name.compareTo(b.name));
+      FirebaseAnalytics.instance.logEvent(name: 'tag_created');
 
       _tagNameCtrl.clear();
       if (mounted) {
@@ -700,7 +703,7 @@ class _TagSelectionScreenState extends State<TagSelectionScreen> {
                             minHeight: 50,
                             maxHeight: 50,
                           ),
-                          hintText: '새 태그 이름을 입력하세요',
+                          hintText: '새 태그 이름 (최대 30자)',
                           hintStyle: baseTextStyle.copyWith(
                             fontSize: 13,
                             color: Colors.grey[500],
@@ -786,9 +789,11 @@ class _TagSelectionScreenState extends State<TagSelectionScreen> {
                           fillColor: Colors.white,
                           filled: true,
                           isDense: false,
+                          counterText: '',
                           contentPadding: const EdgeInsets.symmetric(
                               horizontal: 10, vertical: 12),
                         ),
+                        maxLength: 30,
                         onSubmitted: (_) => _createTag(),
                       ),
                     ),

--- a/lib/Screen/ReviewDue/ReviewDueScreen.dart
+++ b/lib/Screen/ReviewDue/ReviewDueScreen.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:ono/Model/Problem/ReviewDueProblemModel.dart';
 import 'package:ono/Model/Problem/ProblemModel.dart';
@@ -23,6 +24,7 @@ class _ReviewDueScreenState extends State<ReviewDueScreen> {
   @override
   void initState() {
     super.initState();
+    FirebaseAnalytics.instance.logEvent(name: 'review_due_screen_view');
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       final provider = Provider.of<ReviewDueProvider>(context, listen: false);
       if (provider.data == null) {

--- a/lib/Screen/StudyRoom/ProblemPickerScreen.dart
+++ b/lib/Screen/StudyRoom/ProblemPickerScreen.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
@@ -246,7 +247,10 @@ class _ProblemPickerScreenState extends State<ProblemPickerScreen> {
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 520),
-          child: Padding(
+          child: GestureDetector(
+            onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+            behavior: HitTestBehavior.translucent,
+            child: Padding(
             padding: const EdgeInsets.fromLTRB(18, 18, 18, 16),
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -405,6 +409,7 @@ class _ProblemPickerScreenState extends State<ProblemPickerScreen> {
                 ),
               ],
             ),
+            ),
           ),
         ),
       ),
@@ -470,6 +475,7 @@ class _ProblemPickerScreenState extends State<ProblemPickerScreen> {
         problem.problemId,
         comment: comment.isEmpty ? null : comment,
       );
+      FirebaseAnalytics.instance.logEvent(name: 'problem_shared');
       if (mounted) {
         Navigator.pop(context, true);
       }

--- a/lib/Screen/StudyRoom/SharedProblemDetailScreen.dart
+++ b/lib/Screen/StudyRoom/SharedProblemDetailScreen.dart
@@ -270,9 +270,12 @@ class SharedProblemDetailScreen extends StatelessWidget {
           maxLines: 1,
         ),
       ),
-      body: ListView(
-        padding: const EdgeInsets.fromLTRB(18, 8, 18, 32),
-        children: [
+      body: GestureDetector(
+        onTap: () => FocusScope.of(context).unfocus(),
+        behavior: HitTestBehavior.translucent,
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(18, 8, 18, 32),
+          children: [
           _buildDetailHeader(
               context, currentProblem, primary, provider, themeProvider),
           const SizedBox(height: 14),
@@ -303,6 +306,7 @@ class SharedProblemDetailScreen extends StatelessWidget {
             showToggle: false,
           ),
         ],
+        ),
       ),
     );
   }

--- a/lib/Screen/StudyRoom/StudyRoomCreateScreen.dart
+++ b/lib/Screen/StudyRoom/StudyRoomCreateScreen.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
@@ -127,6 +128,7 @@ class _StudyRoomCreateScreenState extends State<StudyRoomCreateScreen> {
           AppSnackBar.showError('방은 만들었지만 사진 등록에 실패했어요');
         }
       }
+      FirebaseAnalytics.instance.logEvent(name: 'study_room_created');
       if (mounted) Navigator.pop(context, true);
     } catch (_) {
       AppSnackBar.showError('방 생성에 실패했습니다');

--- a/lib/Screen/StudyRoom/StudyRoomDetailScreen.dart
+++ b/lib/Screen/StudyRoom/StudyRoomDetailScreen.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -34,6 +35,7 @@ class _StudyRoomDetailScreenState extends State<StudyRoomDetailScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    FirebaseAnalytics.instance.logEvent(name: 'study_room_detail_view');
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadRoom();
     });

--- a/lib/Screen/StudyRoom/StudyRoomJoinScreen.dart
+++ b/lib/Screen/StudyRoom/StudyRoomJoinScreen.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
@@ -51,6 +52,7 @@ class _StudyRoomJoinScreenState extends State<StudyRoomJoinScreen> {
     try {
       await Provider.of<StudyRoomProvider>(context, listen: false)
           .joinRoom(code);
+      FirebaseAnalytics.instance.logEvent(name: 'study_room_joined');
       if (mounted) Navigator.pop(context, true);
     } catch (e) {
       AppSnackBar.showError(_joinErrorMessage(e));

--- a/lib/Screen/StudyRoom/StudyRoomListScreen.dart
+++ b/lib/Screen/StudyRoom/StudyRoomListScreen.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -6,6 +7,7 @@ import '../../Module/Text/StandardText.dart';
 import '../../Module/Theme/ThemeHandler.dart';
 import '../../Provider/StudyRoomProvider.dart';
 import '../../Provider/UserProvider.dart';
+import '../Tutorial/TutorialTargets.dart';
 import 'StudyRoomCreateScreen.dart';
 import 'StudyRoomDetailScreen.dart';
 import 'StudyRoomJoinScreen.dart';
@@ -13,7 +15,9 @@ import 'Widget/StudyRoomEmptyState.dart';
 import 'Widget/StudyRoomThumbnail.dart';
 
 class StudyRoomListScreen extends StatefulWidget {
-  const StudyRoomListScreen({super.key});
+  final TutorialTargets? tutorialTargets;
+
+  const StudyRoomListScreen({super.key, this.tutorialTargets});
 
   @override
   State<StudyRoomListScreen> createState() => _StudyRoomListScreenState();
@@ -23,6 +27,7 @@ class _StudyRoomListScreenState extends State<StudyRoomListScreen> {
   @override
   void initState() {
     super.initState();
+    FirebaseAnalytics.instance.logEvent(name: 'study_room_list_view');
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final provider = Provider.of<StudyRoomProvider>(context, listen: false);
       provider.updateCurrentUserId(
@@ -195,6 +200,7 @@ class _StudyRoomListScreenState extends State<StudyRoomListScreen> {
       floatingActionButton: SizedBox(
         height: 50,
         child: FloatingActionButton.extended(
+          key: widget.tutorialTargets?.studyRoomFabKey,
           heroTag: 'study_room_join_fab',
           onPressed: () => _showAddMenu(themeProvider),
           backgroundColor: themeProvider.primaryColor,

--- a/lib/Screen/StudyRoom/Widget/InviteCodeSheet.dart
+++ b/lib/Screen/StudyRoom/Widget/InviteCodeSheet.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
@@ -198,6 +199,7 @@ class InviteCodeSheet extends StatelessWidget {
 
   void _copyCode(BuildContext context) {
     Clipboard.setData(ClipboardData(text: inviteCode.code));
+    FirebaseAnalytics.instance.logEvent(name: 'invite_code_copied');
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: const StandardText(
@@ -226,6 +228,7 @@ class InviteCodeSheet extends StatelessWidget {
       'OnO 스터디룸 초대 코드: ${inviteCode.code}',
       sharePositionOrigin: origin,
     );
+    FirebaseAnalytics.instance.logEvent(name: 'invite_code_shared');
   }
 }
 

--- a/lib/Screen/StudyRoom/Widget/SharedProblemCommentsSection.dart
+++ b/lib/Screen/StudyRoom/Widget/SharedProblemCommentsSection.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -95,6 +96,7 @@ class _SharedProblemCommentsSectionState
       await context
           .read<StudyRoomProvider>()
           .createSharedProblemComment(widget.sharedProblemId, content);
+      FirebaseAnalytics.instance.logEvent(name: 'comment_created');
       _controller.clear();
     } catch (_) {
       if (mounted) AppSnackBar.showError('풀이 의견을 남기지 못했어요');

--- a/lib/Screen/StudyRoom/Widget/WeeklyReportSheet.dart
+++ b/lib/Screen/StudyRoom/Widget/WeeklyReportSheet.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 
 import '../../../Model/StudyRoom/WeeklyReportModel.dart';
@@ -20,6 +21,7 @@ class WeeklyReportSheet extends StatelessWidget {
     ThemeHandler themeProvider, {
     VoidCallback? onClose,
   }) {
+    FirebaseAnalytics.instance.logEvent(name: 'weekly_report_viewed');
     return showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,

--- a/lib/Screen/Tutorial/TutorialStep.dart
+++ b/lib/Screen/Tutorial/TutorialStep.dart
@@ -18,6 +18,7 @@ enum TutorialTargetType {
   folderList,
   directoryCreateFab,
   practiceCreateFab,
+  studyRoomFab,
   levelCard,
   calendarCard,
   reportCard,
@@ -39,7 +40,7 @@ class TutorialStep {
   });
 }
 
-const int currentTutorialVersion = 1;
+const int currentTutorialVersion = 2;
 
 const List<TutorialStep> tutorialSteps = [
   TutorialStep(
@@ -63,6 +64,13 @@ const List<TutorialStep> tutorialSteps = [
     targetType: TutorialTargetType.practiceCreateFab,
     title: '복습 세트',
     description: '복습 세트는 여러 오답노트를 묶어 다시 푸는 공간이에요.\n시험 전에 필요한 문제만 골라 반복할 수 있어요.',
+  ),
+  TutorialStep(
+    id: 'study_room',
+    tabIndex: 2,
+    targetType: TutorialTargetType.studyRoomFab,
+    title: '스터디룸',
+    description: '스터디룸에서 친구들과 함께 공부해요.\n방을 만들거나 초대 코드로 참여할 수 있어요.',
   ),
   TutorialStep(
     id: 'level',
@@ -96,6 +104,8 @@ extension TutorialTargetResolver on TutorialTargetType {
         return targets.directoryCreateFabKey;
       case TutorialTargetType.practiceCreateFab:
         return targets.practiceCreateFabKey;
+      case TutorialTargetType.studyRoomFab:
+        return targets.studyRoomFabKey;
       case TutorialTargetType.levelCard:
         return targets.levelCardKey;
       case TutorialTargetType.calendarCard:

--- a/lib/Screen/Tutorial/TutorialTargets.dart
+++ b/lib/Screen/Tutorial/TutorialTargets.dart
@@ -4,6 +4,7 @@ class TutorialTargets {
   final GlobalKey folderListKey = GlobalKey();
   final GlobalKey directoryCreateFabKey = GlobalKey();
   final GlobalKey practiceCreateFabKey = GlobalKey();
+  final GlobalKey studyRoomFabKey = GlobalKey();
   final GlobalKey levelCardKey = GlobalKey();
   final GlobalKey calendarCardKey = GlobalKey();
   final GlobalKey reportCardKey = GlobalKey();

--- a/lib/Screen/User/LearningCalendarScreen.dart
+++ b/lib/Screen/User/LearningCalendarScreen.dart
@@ -1,5 +1,7 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../Model/StudyCalendar/StudyCalendarModel.dart';
 import '../../Module/Emoji/OnoEmojiCategory.dart';
 import '../../Module/Emoji/OnoEmojiImage.dart';
@@ -22,6 +24,7 @@ class _LearningCalendarScreenState extends State<LearningCalendarScreen> {
   StudyCalendarModel? _calendarData;
   bool _isLoading = true;
   int? _selectedDay;
+  final TextEditingController _diaryController = TextEditingController();
 
   final StudyCalendarService _service = StudyCalendarService();
 
@@ -51,6 +54,40 @@ class _LearningCalendarScreenState extends State<LearningCalendarScreen> {
     _year = now.year;
     _month = now.month;
     _loadCalendar();
+  }
+
+  @override
+  void dispose() {
+    _diaryController.dispose();
+    super.dispose();
+  }
+
+  String _diaryKey(int year, int month, int day) =>
+      'diary_text_${year}_${month}_${day}';
+
+  Future<void> _loadDiary(int year, int month, int day) async {
+    final prefs = await SharedPreferences.getInstance();
+    final text = prefs.getString(_diaryKey(year, month, day)) ?? '';
+    if (!mounted) return;
+    setState(() => _diaryController.text = text);
+  }
+
+  Future<void> _saveDiary(int year, int month, int day, String text) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = _diaryKey(year, month, day);
+    if (text.isEmpty) {
+      await prefs.remove(key);
+    } else {
+      await prefs.setString(key, text);
+    }
+    if (!mounted) return;
+    FirebaseAnalytics.instance.logEvent(name: 'calendar_diary_saved');
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('다이어리가 저장되었어요.'),
+        duration: Duration(seconds: 2),
+      ),
+    );
   }
 
   Future<void> _loadCalendar() async {
@@ -376,10 +413,13 @@ class _LearningCalendarScreenState extends State<LearningCalendarScreen> {
                       themeProvider: themeProvider,
                       onTap: isFuture
                           ? null
-                          : () => setState(() {
-                                _selectedDay =
-                                    (_selectedDay == day) ? null : day;
-                              }),
+                          : () {
+                              final newDay = (_selectedDay == day) ? null : day;
+                              setState(() => _selectedDay = newDay);
+                              if (newDay != null) {
+                                _loadDiary(_year, _month, newDay);
+                              }
+                            },
                     ),
                   ),
                 ),
@@ -498,9 +538,87 @@ class _LearningCalendarScreenState extends State<LearningCalendarScreen> {
                     )),
               ],
             ],
+            const SizedBox(height: 14),
+            _buildDiarySection(themeProvider),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildDiarySection(ThemeHandler themeProvider) {
+    final primaryColor = themeProvider.primaryColor;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.edit_note, size: 15, color: Colors.black45),
+            const SizedBox(width: 6),
+            StandardText(
+              text: '하루 기록',
+              fontSize: 12,
+              color: Colors.black45,
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        TextField(
+          controller: _diaryController,
+          maxLines: 4,
+          maxLength: 300,
+          style: const TextStyle(fontSize: 13, color: Colors.black87),
+          decoration: InputDecoration(
+            hintText: '오늘 하루를 기록해보세요...',
+            hintStyle: TextStyle(fontSize: 13, color: Colors.grey[400]),
+            filled: true,
+            fillColor: Colors.white,
+            counterStyle:
+                TextStyle(fontSize: 10, color: Colors.grey[400]),
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: Colors.grey[300]!),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: Colors.grey[300]!),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: primaryColor.withOpacity(0.5)),
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton(
+            onPressed: () {
+              final text = _diaryController.text.trim();
+              _saveDiary(_year, _month, _selectedDay!, text);
+              FocusScope.of(context).unfocus();
+            },
+            style: TextButton.styleFrom(
+              backgroundColor: primaryColor,
+              foregroundColor: Colors.white,
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+              minimumSize: const Size(72, 34),
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: const StandardText(
+              text: '저장',
+              fontSize: 13,
+              color: Colors.white,
+            ),
+          ),
+        ),
+      ],
     );
   }
 
@@ -634,6 +752,7 @@ class _LearningCalendarScreenState extends State<LearningCalendarScreen> {
             emojiKey: emoji.key,
             showErrorSnackBar: false,
           );
+          FirebaseAnalytics.instance.logEvent(name: 'mood_set');
           if (!mounted) return;
           await _loadCalendar();
         } catch (_) {

--- a/lib/Screen/User/LearningCalendarScreen.dart
+++ b/lib/Screen/User/LearningCalendarScreen.dart
@@ -25,6 +25,7 @@ class _LearningCalendarScreenState extends State<LearningCalendarScreen> {
   bool _isLoading = true;
   int? _selectedDay;
   final TextEditingController _diaryController = TextEditingController();
+  int _loadDiarySeq = 0;
 
   final StudyCalendarService _service = StudyCalendarService();
 
@@ -66,10 +67,11 @@ class _LearningCalendarScreenState extends State<LearningCalendarScreen> {
       'diary_text_${year}_${month}_${day}';
 
   Future<void> _loadDiary(int year, int month, int day) async {
+    final seq = ++_loadDiarySeq;
     final prefs = await SharedPreferences.getInstance();
     final text = prefs.getString(_diaryKey(year, month, day)) ?? '';
-    if (!mounted) return;
-    setState(() => _diaryController.text = text);
+    if (!mounted || seq != _loadDiarySeq) return;
+    _diaryController.text = text;
   }
 
   Future<void> _saveDiary(int year, int month, int day, String text) async {
@@ -596,8 +598,10 @@ class _LearningCalendarScreenState extends State<LearningCalendarScreen> {
           alignment: Alignment.centerRight,
           child: TextButton(
             onPressed: () {
+              final day = _selectedDay;
+              if (day == null) return;
               final text = _diaryController.text.trim();
-              _saveDiary(_year, _month, _selectedDay!, text);
+              _saveDiary(_year, _month, day, text);
               FocusScope.of(context).unfocus();
             },
             style: TextButton.styleFrom(

--- a/lib/Screen/User/MyPageScreen.dart
+++ b/lib/Screen/User/MyPageScreen.dart
@@ -720,6 +720,8 @@ void _showChangeNameDialog(BuildContext context, String currentName) {
                           email: null,
                           identifier: null,
                         );
+                        FirebaseAnalytics.instance
+                            .logEvent(name: 'username_updated');
                       }
                     },
                     style: TextButton.styleFrom(

--- a/lib/Service/SocialLogin/AppleAuthService.dart
+++ b/lib/Service/SocialLogin/AppleAuthService.dart
@@ -32,10 +32,9 @@ class AppleAuthService {
       return UserRegisterModel(
           email: email, name: name, identifier: identifier, platform: "APPLE");
     } catch (error, stackTrace) {
-      if (error == AuthorizationErrorCode.canceled) {
-        return null;
-      }
-      if (error == AuthorizationErrorCode.unknown) {
+      if (error is SignInWithAppleAuthorizationException &&
+          (error.code == AuthorizationErrorCode.canceled ||
+              error.code == AuthorizationErrorCode.unknown)) {
         return null;
       }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -266,7 +266,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
     final widgetOptions = <Widget>[
       DirectoryScreen(tutorialTargets: _tutorialTargets),
       PracticeThumbnailScreen(tutorialTargets: _tutorialTargets),
-      const StudyRoomListScreen(),
+      StudyRoomListScreen(tutorialTargets: _tutorialTargets),
       SettingScreen(tutorialTargets: _tutorialTargets),
     ];
 


### PR DESCRIPTION
## ✔️ 연관 이슈

- 없음

## 📝 작업 내용

> 3.6.1 배포 전후 안정성 개선과 학습 흐름 추적 기능을 반영했습니다.

- Apple 로그인 취소/알 수 없음 상태를 오류로 수집하지 않도록 처리했습니다.
- FlutterSecureStorage BAD_DECRYPT 감지 범위를 보강하고, 보안 저장소 손상 시 토큰 삭제 후 로그인 흐름으로 전환되도록 개선했습니다.
- 학습 달력에서 날짜별 하루 기록 작성/저장과 감정 선택 이벤트를 추가했습니다.
- 태그 이름 30자 초과 생성을 클라이언트에서 방어하고 안내 문구를 조정했습니다.
- 튜토리얼 스터디룸 단계와 주요 화면의 Firebase Analytics 이벤트를 추가했습니다.

### 스크린샷 (선택)

- UI 변경 포함: 학습 달력 날짜 상세의 하루 기록 영역, 태그 생성 입력 안내, 튜토리얼 단계
- 스크린샷은 첨부하지 않았습니다.

## 검증

- 이번 PR 생성 과정에서는 `flutter analyze`, `dart format`, 화면 실행 검증을 새로 수행하지 않았습니다.
- 커밋된 변경 기준으로 `origin/develop..HEAD` diff를 확인했습니다.

## 배포 리스크 / 확인 필요

- 학습 달력 하루 기록 저장 API와 감정 저장 API의 운영 응답 형태 확인이 필요합니다.
- Firebase Analytics 이벤트명 수집 여부는 Firebase 콘솔에서 사후 확인이 필요합니다.
- 현재 로컬에 커밋되지 않은 `ios/Runner.xcodeproj/project.pbxproj` 변경이 있으며, 이 PR에는 포함되지 않습니다.